### PR TITLE
Add missing Dependencies and PathWhitelist after the collapse of app and fileset manifests.

### DIFF
--- a/schema/app.go
+++ b/schema/app.go
@@ -12,12 +12,14 @@ const (
 )
 
 type ImageManifest struct {
-	ACKind      types.ACKind      `json:"acKind"`
-	ACVersion   types.SemVer      `json:"acVersion"`
-	Name        types.ACName      `json:"name"`
-	Labels      types.Labels      `json:"labels"`
-	App         types.App         `json:"app"`
-	Annotations types.Annotations `json:"annotations"`
+	ACKind        types.ACKind       `json:"acKind"`
+	ACVersion     types.SemVer       `json:"acVersion"`
+	Name          types.ACName       `json:"name"`
+	Labels        types.Labels       `json:"labels"`
+	App           types.App          `json:"app"`
+	Annotations   types.Annotations  `json:"annotations"`
+	Dependencies  types.Dependencies `json:"dependencies"`
+	PathWhitelist []string           `json:"pathWhitelist"`
 }
 
 // appManifest is a model to facilitate extra validation during the

--- a/schema/types/dependencies.go
+++ b/schema/types/dependencies.go
@@ -1,0 +1,43 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type Dependencies []Dependency
+
+type Dependency struct {
+	Name   ACName `json:"name"`
+	Hash   Hash   `json:"hash"`
+	Labels Labels `json:"labels"`
+}
+
+type dependency Dependency
+
+func (d Dependency) assertValid() error {
+	if len(d.Name) < 1 {
+		return errors.New(`Name cannot be empty`)
+	}
+	return nil
+}
+
+func (d Dependency) MarshalJSON() ([]byte, error) {
+	if err := d.assertValid(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(dependency(d))
+}
+
+func (d *Dependency) UnmarshalJSON(data []byte) error {
+	var jd dependency
+	if err := json.Unmarshal(data, &jd); err != nil {
+		return err
+	}
+	nd := Dependency(jd)
+	if err := nd.assertValid(); err != nil {
+		return err
+	}
+	*d = nd
+	return nil
+}


### PR DESCRIPTION
Trying of an implementation for #16 I noticed that they were missing.

The original pull request was coreos/rocket#253 (before the split) 
After the review I removed the Root entry from dependencies (the spec should be updated to remove it also from the example), made Hash of type types.Hash and put Name above Hash.
