### PR TITLE
build: only use internal gopath

### DIFF
--- a/build
+++ b/build
@@ -9,7 +9,7 @@ if [ ! -h gopath/src/${REPO_PATH} ]; then
 fi
 
 export GOBIN=${PWD}/bin
-export GOPATH=${GOPATH}:${PWD}/gopath
+export GOPATH=${PWD}/gopath
 
 eval $(go env)
 


### PR DESCRIPTION
I am not really sure why GOPATH is in there, maybe a relic from an earlier incarnation of the rocket repo, but it should not be necessary and only leads to confusion.
