### PR TITLE
Fix optional app and required app.user and app.group.

### DIFF
--- a/schema/app.go
+++ b/schema/app.go
@@ -16,7 +16,7 @@ type ImageManifest struct {
 	ACVersion     types.SemVer       `json:"acVersion"`
 	Name          types.ACName       `json:"name"`
 	Labels        types.Labels       `json:"labels"`
-	App           types.App          `json:"app"`
+	App           *types.App         `json:"app,omitempty"`
 	Annotations   types.Annotations  `json:"annotations"`
 	Dependencies  types.Dependencies `json:"dependencies"`
 	PathWhitelist []string           `json:"pathWhitelist"`

--- a/schema/app_test.go
+++ b/schema/app_test.go
@@ -1,0 +1,32 @@
+package schema
+
+import "testing"
+
+func TestEmptyApp(t *testing.T) {
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test"
+		}
+		`
+
+	var im ImageManifest
+
+	err := im.UnmarshalJSON([]byte(imj))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Marshal and Unmarshal to verify that no "app": {} is generated on
+	// Marshal and converted to empty struct on Unmarshal
+	buf, err := im.MarshalJSON()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	err = im.UnmarshalJSON(buf)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/schema/types/app.go
+++ b/schema/types/app.go
@@ -52,5 +52,11 @@ func (a *App) assertValid() error {
 	if !filepath.IsAbs(a.Exec[0]) {
 		return errors.New(`Exec[0] must be absolute path`)
 	}
+	if a.User == "" {
+		return errors.New(`User is required`)
+	}
+	if a.Group == "" {
+		return errors.New(`Group is required`)
+	}
 	return nil
 }

--- a/schema/types/app_test.go
+++ b/schema/types/app_test.go
@@ -5,13 +5,19 @@ import "testing"
 func TestAppValid(t *testing.T) {
 	tests := []App{
 		App{
-			Exec: []string{"/bin/httpd"},
+			Exec:  []string{"/bin/httpd"},
+			User:  "0",
+			Group: "0",
 		},
 		App{
-			Exec: []string{"/app"},
+			Exec:  []string{"/app"},
+			User:  "0",
+			Group: "0",
 		},
 		App{
-			Exec: []string{"/app", "arg1", "arg2"},
+			Exec:  []string{"/app", "arg1", "arg2"},
+			User:  "0",
+			Group: "0",
 		},
 	}
 	for i, tt := range tests {
@@ -27,13 +33,40 @@ func TestAppInvalid(t *testing.T) {
 			Exec: nil,
 		},
 		App{
-			Exec: []string{},
+			Exec:  []string{},
+			User:  "0",
+			Group: "0",
 		},
 		App{
-			Exec: []string{"app"},
+			Exec:  []string{"app"},
+			User:  "0",
+			Group: "0",
 		},
 		App{
-			Exec: []string{"bin/app", "arg1"},
+			Exec:  []string{"bin/app", "arg1"},
+			User:  "0",
+			Group: "0",
+		},
+	}
+	for i, tt := range tests {
+		if err := tt.assertValid(); err == nil {
+			t.Errorf("#%d: err == nil, want non-nil", i)
+		}
+	}
+}
+
+func TestUserGroupInvalid(t *testing.T) {
+	tests := []App{
+		App{
+			Exec: []string{"/app"},
+		},
+		App{
+			Exec: []string{"/app"},
+			User: "0",
+		},
+		App{
+			Exec:  []string{"app"},
+			Group: "0",
 		},
 	}
 	for i, tt := range tests {


### PR DESCRIPTION
From the spec "app" is optional. I made it a pointer to avoid the validation of an empty field. This will affect applications using this package but this is usually the way go json handle empty json and I didn't find a better way.

Also user and group are defined as required so I added a validation.
