### PR TITLE
schema/types: add Hash.Set() UUID.Set(), and Hash.Empty()

### DIFF
--- a/schema/types/hash.go
+++ b/schema/types/hash.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -35,6 +36,18 @@ func NewHash(s string) (*Hash, error) {
 
 func (h Hash) String() string {
 	return fmt.Sprintf("%s-%s", h.typ, h.Val)
+}
+
+func (h *Hash) Set(s string) error {
+	nh, err := NewHash(s)
+	if err == nil {
+		*h = *nh
+	}
+	return err
+}
+
+func (h Hash) Empty() bool {
+	return reflect.DeepEqual(h, Hash{})
 }
 
 func (h Hash) assertValid() error {

--- a/schema/types/uuid.go
+++ b/schema/types/uuid.go
@@ -25,6 +25,14 @@ func (u UUID) String() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:16])
 }
 
+func (u *UUID) Set(s string) error {
+	nu, err := NewUUID(s)
+	if err == nil {
+		*u = *nu
+	}
+	return err
+}
+
 // NewUUID generates a new UUID from the given string. If the string does not
 // represent a valid UUID, nil and an error are returned.
 func NewUUID(s string) (*UUID, error) {


### PR DESCRIPTION
Set() in addition to String() fulfills the flag.Value interface enabling
convenient commandline parsing for these types as Var flags.

Hash.Empty() is just useful like UUID.Empty(), I'm presently using them
check if variables of these types have been set to anything as flags.
