### PR TITLE
spec: enforce absolute path to exec

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -476,7 +476,7 @@ JSON Schema for the Image Manifest
     * **os** (currently, the only supported value is "linux"). Together with "arch", this can be considered to describe the syscall ABI this image requires.
     * **arch** (currently, the only supported value is "amd64"). Together with "os", this can be considered to describe the syscall ABI this image requires.
 * **app** is optional. If present, this defines the default parameters that can be used to execute this image as an application.
-    * **exec** the executable to launch and any flags (array of strings, must be non-empty; ACE can append or override)
+    * **exec** the executable to launch and any flags (array of strings, must be non-empty; executor must be an absolute path within the app rootfs; ACE can append or override)
     * **user**, **group** are required, and indicate either the UID/GID or the username/group name the app should run as inside the container (freeform string). If the user or group field begins with a "/", the owner and group of the file found at that absolute path inside the rootfs is used as the UID/GID of the process.
     * **eventHandlers** are optional, and should be a list of eventHandler objects. eventHandlers allow the app to have several hooks based on lifecycle events. For example, you may want to execute a script before the main process starts up to download a dataset or backup onto the filesystem. An eventHandler is a simple object with two fields - an **exec** (array of strings, ACE can append or override), and a **name**, which should be one of:
         * **pre-start** - will be executed and must exit before the long running main **exec** binary is launched

--- a/schema/types/app.go
+++ b/schema/types/app.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"errors"
+	"path/filepath"
 )
 
 type App struct {
@@ -47,6 +48,9 @@ func (a App) MarshalJSON() ([]byte, error) {
 func (a *App) assertValid() error {
 	if len(a.Exec) < 1 {
 		return errors.New(`Exec cannot be empty`)
+	}
+	if !filepath.IsAbs(a.Exec[0]) {
+		return errors.New(`Exec[0] must be absolute path`)
 	}
 	return nil
 }

--- a/schema/types/app_test.go
+++ b/schema/types/app_test.go
@@ -1,0 +1,44 @@
+package types
+
+import "testing"
+
+func TestAppValid(t *testing.T) {
+	tests := []App{
+		App{
+			Exec: []string{"/bin/httpd"},
+		},
+		App{
+			Exec: []string{"/app"},
+		},
+		App{
+			Exec: []string{"/app", "arg1", "arg2"},
+		},
+	}
+	for i, tt := range tests {
+		if err := tt.assertValid(); err != nil {
+			t.Errorf("#%d: err == %v, want nil", i, err)
+		}
+	}
+}
+
+func TestAppInvalid(t *testing.T) {
+	tests := []App{
+		App{
+			Exec: nil,
+		},
+		App{
+			Exec: []string{},
+		},
+		App{
+			Exec: []string{"app"},
+		},
+		App{
+			Exec: []string{"bin/app", "arg1"},
+		},
+	}
+	for i, tt := range tests {
+		if err := tt.assertValid(); err == nil {
+			t.Errorf("#%d: err == nil, want non-nil", i)
+		}
+	}
+}


### PR DESCRIPTION
We should ensure that the first argument to the app.exec array is an absolute path.
