### PR TITLE
schema/types/hash: Restore NewHashSHA256()

### DIFF
--- a/schema/types/hash.go
+++ b/schema/types/hash.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/json"
 	"errors"
@@ -87,6 +88,13 @@ func (h Hash) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(h.String())
+}
+
+func NewHashSHA256(b []byte) *Hash {
+	h := sha256.New()
+	h.Write(b)
+	nh, _ := NewHash(fmt.Sprintf("sha256-%x", h.Sum(nil)))
+	return nh
 }
 
 func NewHashSHA512(b []byte) *Hash {


### PR DESCRIPTION
Changing the default from sha256 to sha512 doesn't require that we
remove support for sha256, nor should we break existing programs
which currently call NewHashSHA256() directly.
