### PR TITLE
actool: Emit warnings for Exec files absent from image

### DIFF
--- a/aci/writer.go
+++ b/aci/writer.go
@@ -4,7 +4,10 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/appc/spec/schema"
@@ -20,7 +23,8 @@ type ArchiveWriter interface {
 
 type imageArchiveWriter struct {
 	*tar.Writer
-	am *schema.ImageManifest
+	am         *schema.ImageManifest
+	foundExecs map[string]bool
 }
 
 // NewImageWriter creates a new ArchiveWriter which will generate an App
@@ -30,7 +34,17 @@ func NewImageWriter(am schema.ImageManifest, w *tar.Writer) ArchiveWriter {
 	aw := &imageArchiveWriter{
 		w,
 		&am,
+		map[string]bool{},
 	}
+
+	addExec := func(path string) {
+		aw.foundExecs[filepath.Join("rootfs", path)] = false
+	}
+	addExec(am.App.Exec[0])
+	for _, eh := range am.App.EventHandlers {
+		addExec(eh.Exec[0])
+	}
+
 	return aw
 }
 
@@ -45,6 +59,10 @@ func (aw *imageArchiveWriter) AddFile(path string, hdr *tar.Header, r io.Reader)
 		if err != nil {
 			return err
 		}
+	}
+
+	if _, exec := aw.foundExecs[path]; exec {
+		aw.foundExecs[path] = true
 	}
 
 	return nil
@@ -79,6 +97,12 @@ func (aw *imageArchiveWriter) addManifest(name string, m json.Marshaler) error {
 func (aw *imageArchiveWriter) Close() error {
 	if err := aw.addManifest(ManifestFile, aw.am); err != nil {
 		return err
+	}
+
+	for exec, present := range aw.foundExecs {
+		if present == false {
+			fmt.Fprintf(os.Stderr, "WARNING: Exec %q is absent from image\n", exec)
+		}
 	}
 	return aw.Writer.Close()
 }


### PR DESCRIPTION
It may make more sense to just fail when one's absent, unless we want to
support bind mounts bringing executables to the party.

I consider this a step towards a partial solution to https://github.com/coreos/rocket/issues/286
