### PR TITLE
SPEC: have discovery walk up the tree

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -276,6 +276,10 @@ keys: https://example.com/pubkeys.gpg
 ```
 
 This mechanism is only used for discovery of contents URLs.
+
+If the first attempt at fetching the discovery URL returns a status code other than `200 OK` or does not contain any `ac-discovery` meta tags then the next higher path in the name should be tried.
+For example if the user has `example.com/project/subproject` and we first try `example.com/project/subproject` but don't find a meta tag then try `example.com/project` then try `example.com`.
+
 Anything implementing this spec should enforce any signing rules set in place by the operator and ensure the image manifest provided by the fetched app image are all prefixed from the same domain.
 
 Discovery URLs that require interpolation are [RFC6570](https://tools.ietf.org/html/rfc6570) URI templates.

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1,75 +1,144 @@
 package discovery
 
 import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
 )
 
-func fakeHTTPGet(filename string) func(uri string) (*http.Response, error) {
+func fakeHTTPGet(filename string, failures int) func(uri string) (*http.Response, error) {
+	attempts := 0
 	return func(uri string) (*http.Response, error) {
 		f, err := os.Open(filename)
 		if err != nil {
 			return nil, err
 		}
 
-		return &http.Response{
-			Status:     "200 OK",
-			StatusCode: 200,
-			Proto:      "HTTP/1.1",
-			ProtoMajor: 1,
-			ProtoMinor: 1,
-			Header: http.Header{
-				"Content-Type": []string{"text/html"},
-			},
-			Body: f,
-		}, nil
+		var resp *http.Response
+
+		switch {
+		case attempts < failures:
+			resp = &http.Response{
+				Status:     "404 Not Found",
+				StatusCode: http.StatusNotFound,
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header: http.Header{
+					"Content-Type": []string{"text/html"},
+				},
+				Body: ioutil.NopCloser(bytes.NewBufferString("")),
+			}
+		default:
+			resp = &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header: http.Header{
+					"Content-Type": []string{"text/html"},
+				},
+				Body: f,
+			}
+		}
+
+		attempts = attempts + 1
+		return resp, nil
 	}
 }
 
-func TestDiscoverEndpoints(t *testing.T) {
-	httpGet = fakeHTTPGet("myapp.html")
+type httpgetter func(uri string) (*http.Response, error)
 
-	a := App{
-		Name: "example.com/myapp",
-		Labels: map[string]string{
-			"version": "1.0.0",
-			"os":      "linux",
-			"arch":    "amd64",
+func TestDiscoverEndpoints(t *testing.T) {
+	tests := []struct {
+		get httpgetter
+		expectDiscoverySuccess bool
+		app App
+	}{
+		{
+			fakeHTTPGet("myapp.html", 0),
+			true,
+			App{
+				Name: "example.com/myapp",
+				Labels: map[string]string{
+					"version": "1.0.0",
+					"os":      "linux",
+					"arch":    "amd64",
+				},
+			},
+		},
+		{
+			fakeHTTPGet("myapp.html", 1),
+			true,
+			App{
+				Name: "example.com/myapp/foobar",
+				Labels: map[string]string{
+					"version": "1.0.0",
+					"os":      "linux",
+					"arch":    "amd64",
+				},
+			},
+		},
+		{
+			fakeHTTPGet("myapp.html", 20),
+			false,
+			App{
+				Name: "example.com/myapp/foobar/bazzer",
+				Labels: map[string]string{
+					"version": "1.0.0",
+					"os":      "linux",
+					"arch":    "amd64",
+				},
+			},
 		},
 	}
-	de, err := DiscoverEndpoints(a, true)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	if len(de.Sig) != 2 {
-		t.Errorf("Sig array is wrong length")
-	} else {
-		if de.Sig[0] != "https://storage.example.com/example.com/myapp-1.0.0.sig?torrent" {
-			t.Error("Sig[0] mismatch: ", de.Sig[0])
+	for i, tt := range tests {
+		httpGet = tt.get
+		de, err := DiscoverEndpoints(tt.app, true)
+		if err != nil && !tt.expectDiscoverySuccess {
+			continue
 		}
-		if de.Sig[1] != "hdfs://storage.example.com/example.com/myapp-1.0.0.sig" {
-			t.Error("Sig[1] mismatch: ", de.Sig[0])
+		if err != nil {
+			t.Fatalf("#%d DiscoverEndpoints failed: %v", i, err)
 		}
-	}
 
-	if len(de.ACI) != 2 {
-		t.Errorf("ACI array is wrong length")
-	} else {
-		if de.ACI[0] != "https://storage.example.com/example.com/myapp-1.0.0.aci?torrent" {
-			t.Error("ACI[0] mismatch: ", de.ACI[0])
+		if len(de.Sig) != 2 {
+			t.Errorf("Sig array is wrong length want %d got %d", 2, len(de.Sig))
+		} else {
+			tor := fmt.Sprintf("https://storage.example.com/%s-%s.sig?torrent", tt.app.Name, tt.app.Labels["version"])
+			if de.Sig[0] != tor {
+				t.Errorf("#%d sig[0] mismatch: want %v got %v", i, tor, de.Sig[0])
+			}
+			hdfs := fmt.Sprintf("hdfs://storage.example.com/%s-%s.sig", tt.app.Name, tt.app.Labels["version"])
+			if de.Sig[1] != hdfs {
+				t.Errorf("#%d sig[1] mismatch want %v got %v", i, hdfs, de.Sig[0])
+			}
 		}
-		if de.ACI[1] != "hdfs://storage.example.com/example.com/myapp-1.0.0.aci" {
-			t.Error("ACI[1] mismatch: ", de.ACI[1])
-		}
-	}
 
-	if len(de.Keys) != 1 {
-		t.Errorf("Keys array is wrong length")
-	} else {
-		if de.Keys[0] != "https://example.com/pubkeys.gpg" {
-			t.Error("Keys[0] mismatch: ", de.Keys[0])
+		if len(de.ACI) != 2 {
+			t.Errorf("ACI array is wrong length")
+		} else {
+			tor := fmt.Sprintf("https://storage.example.com/%s-%s.aci?torrent", tt.app.Name, tt.app.Labels["version"])
+			if de.ACI[0] != tor {
+				t.Errorf("#%d ACI[0] mismatch want %v got %v", i, tor, de.ACI[0])
+			}
+			hdfs := fmt.Sprintf("hdfs://storage.example.com/%s-%s.aci", tt.app.Name, tt.app.Labels["version"])
+			if de.ACI[1] != hdfs {
+				t.Errorf("#%d ACI[1] mismatch want %v got %v", i, hdfs, de.ACI[1])
+			}
+		}
+
+		if len(de.Keys) != 1 {
+			t.Errorf("Keys array is wrong length")
+		} else {
+			if de.Keys[0] != "https://example.com/pubkeys.gpg" {
+				t.Error("Keys[0] mismatch: ", de.Keys[0])
+			}
 		}
 	}
 }

--- a/discovery/http.go
+++ b/discovery/http.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -25,12 +26,17 @@ func httpsOrHTTP(name string, insecure bool) (urlStr string, body io.ReadCloser,
 		}
 	}
 	urlStr, res, err := fetch("https")
-	if err != nil || res.StatusCode != 200 {
+	if err != nil || res.StatusCode != http.StatusOK {
 		closeBody(res)
 		if insecure {
 			urlStr, res, err = fetch("http")
 		}
 	}
+
+	if res.StatusCode != http.StatusOK {
+		err = fmt.Errorf("expected a 200 OK got %d", res.StatusCode)
+	}
+
 	if err != nil {
 		closeBody(res)
 		return "", nil, err


### PR DESCRIPTION
The basic idea is that people may not want to have a landing page for
every container name but will instead want a landing page for an overall
project. This would let people do this as the discovery algorithm will
walk up the tree from example.com/project/app1 to example.com/project to
example.com.
