### PR TITLE
schema: Fix optional Dependency.ImageID

### DIFF
--- a/schema/types/dependencies.go
+++ b/schema/types/dependencies.go
@@ -9,7 +9,7 @@ type Dependencies []Dependency
 
 type Dependency struct {
 	App     ACName `json:"app"`
-	ImageID Hash   `json:"imageID,omitempty"`
+	ImageID *Hash  `json:"imageID,omitempty"`
 	Labels  Labels `json:"labels,omitempty"`
 }
 

--- a/schema/types/dependencies_test.go
+++ b/schema/types/dependencies_test.go
@@ -1,0 +1,26 @@
+package types
+
+import "testing"
+
+func TestEmptyHash(t *testing.T) {
+	dj := `{"app": "example.com/reduce-worker-base"}`
+
+	var d Dependency
+
+	err := d.UnmarshalJSON([]byte(dj))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Marshal to verify that marshalling works without validation errors
+	buf, err := d.MarshalJSON()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Unmarshal to verify that the generated json will not create wrong empty hash
+	err = d.UnmarshalJSON(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
As in #37 Dependency.ImageID is optional.

Unmarshalling a json or programmaticaly creating an ImageManifest without a dependency's ImageID will create an empty ImageId Hash struct. On Marshall it will call assertValid that will correctly fail.

This patch makes ImageID a pointer. I made a different fix here: 23b834b2a3da76b5797c3c92a3a198f875dfb0c3. This is the rationale:

The typical and fast solution is to make ImageID a pointer so on Marshall it won't call assertValid as it's a null object (see ).
The downside is that every Dependency struct's user should verify that ImageID isn't nil before doing any operation. Plus Hash has already an IsEmpty function, so there're can be nil ImageID or an empty ImageID creating some confusion.

There's a need for go json to not Marshal "zero"/empty structs like is already done for builtin types if omitempty is specified: golang/go#4357. Until this is accepted/introduced the solution is to use a pointer/interface{} or a custom Marshal function (this is costly if the number of possible empty fields is big due to the possible combinations).

What do you think about the two possible solutions?

Thanks!

