### PR TITLE
schema: add omitempty json tag option to optional types.

### DIFF
--- a/schema/image.go
+++ b/schema/image.go
@@ -15,11 +15,11 @@ type ImageManifest struct {
 	ACKind        types.ACKind       `json:"acKind"`
 	ACVersion     types.SemVer       `json:"acVersion"`
 	Name          types.ACName       `json:"name"`
-	Labels        types.Labels       `json:"labels"`
+	Labels        types.Labels       `json:"labels,omitempty"`
 	App           *types.App         `json:"app,omitempty"`
-	Annotations   types.Annotations  `json:"annotations"`
-	Dependencies  types.Dependencies `json:"dependencies"`
-	PathWhitelist []string           `json:"pathWhitelist"`
+	Annotations   types.Annotations  `json:"annotations,omitempty"`
+	Dependencies  types.Dependencies `json:"dependencies,omitempty"`
+	PathWhitelist []string           `json:"pathWhitelist,omitempty"`
 }
 
 // imageManifest is a model to facilitate extra validation during the

--- a/schema/types/app.go
+++ b/schema/types/app.go
@@ -8,13 +8,13 @@ import (
 
 type App struct {
 	Exec          []string          `json:"exec"`
-	EventHandlers []EventHandler    `json:"eventHandlers"`
+	EventHandlers []EventHandler    `json:"eventHandlers,omitempty"`
 	User          string            `json:"user"`
 	Group         string            `json:"group"`
-	Environment   map[string]string `json:"environment"`
-	MountPoints   []MountPoint      `json:"mountPoints"`
-	Ports         []Port            `json:"ports"`
-	Isolators     []Isolator        `json:"isolators"`
+	Environment   map[string]string `json:"environment,omitempty"`
+	MountPoints   []MountPoint      `json:"mountPoints,omitempty"`
+	Ports         []Port            `json:"ports,omitempty"`
+	Isolators     []Isolator        `json:"isolators,omitempty"`
 }
 
 // app is a model to facilitate extra validation during the

--- a/schema/types/dependencies.go
+++ b/schema/types/dependencies.go
@@ -9,8 +9,8 @@ type Dependencies []Dependency
 
 type Dependency struct {
 	App     ACName `json:"app"`
-	ImageID Hash   `json:"imageID"`
-	Labels  Labels `json:"labels"`
+	ImageID Hash   `json:"imageID,omitempty"`
+	Labels  Labels `json:"labels,omitempty"`
 }
 
 type dependency Dependency

--- a/schema/types/mountpoint.go
+++ b/schema/types/mountpoint.go
@@ -3,5 +3,5 @@ package types
 type MountPoint struct {
 	Name     ACName `json:"name"`
 	Path     string `json:"path"`
-	ReadOnly bool   `json:"readOnly"`
+	ReadOnly bool   `json:"readOnly,omitempty"`
 }


### PR DESCRIPTION
As discussed in https://github.com/appc/spec/pull/37#discussion_r21776456 and in #55 
On Marshal empty types will be omitted instead of creating a lot of
"type": null json objects.

Example.
Before:

```
{
    "acKind": "ImageManifest",
    "acVersion": "0.1.1",
    "name": "example.com/test",
    "dependencies": [
        {
            "app": "example.com/test02",
            "imageID": "sha512-c98bf6328037ba1272e2a36142405835ced3e44504e39eb9d02f64f59f598790",
            "labels": null
        }
    ],
    "labels": null,
    "pathWhitelist": null
    "annotations": null,
}
```

After:

```
{
    "acKind": "ImageManifest",
    "acVersion": "0.1.1",
    "name": "example.com/test",
    "dependencies": [
        {
            "app": "example.com/test02",
            "imageID": "sha512-c98bf6328037ba1272e2a36142405835ced3e44504e39eb9d02f64f59f598790"
        }
    ]
}
```
