### PR TITLE
schema/types: split out Exec to its own type

### DIFF
--- a/schema/types/app.go
+++ b/schema/types/app.go
@@ -3,11 +3,10 @@ package types
 import (
 	"encoding/json"
 	"errors"
-	"path/filepath"
 )
 
 type App struct {
-	Exec          []string          `json:"exec"`
+	Exec          Exec              `json:"exec"`
 	EventHandlers []EventHandler    `json:"eventHandlers,omitempty"`
 	User          string            `json:"user"`
 	Group         string            `json:"group"`
@@ -46,11 +45,8 @@ func (a App) MarshalJSON() ([]byte, error) {
 }
 
 func (a *App) assertValid() error {
-	if len(a.Exec) < 1 {
-		return errors.New(`Exec cannot be empty`)
-	}
-	if !filepath.IsAbs(a.Exec[0]) {
-		return errors.New(`Exec[0] must be absolute path`)
+	if err := a.Exec.assertValid(); err != nil {
+		return err
 	}
 	if a.User == "" {
 		return errors.New(`User is required`)

--- a/schema/types/event_handler.go
+++ b/schema/types/event_handler.go
@@ -7,8 +7,8 @@ import (
 )
 
 type EventHandler struct {
-	Name string   `json:"name"`
-	Exec []string `json:"exec"`
+	Name string `json:"name"`
+	Exec Exec   `json:"exec"`
 }
 
 type eventHandler EventHandler

--- a/schema/types/exec.go
+++ b/schema/types/exec.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+)
+
+type Exec []string
+
+type exec Exec
+
+func (e Exec) assertValid() error {
+	if len(e) < 1 {
+		return errors.New(`Exec cannot be empty`)
+	}
+	if !filepath.IsAbs(e[0]) {
+		return errors.New(`Exec[0] must be absolute path`)
+	}
+	return nil
+}
+
+func (e Exec) MarshalJSON() ([]byte, error) {
+	if err := e.assertValid(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(exec(e))
+}
+
+func (e *Exec) UnmarshalJSON(data []byte) error {
+	var je exec
+	err := json.Unmarshal(data, &je)
+	if err != nil {
+		return err
+	}
+	ne := Exec(je)
+	if err := ne.assertValid(); err != nil {
+		return err
+	}
+	*e = ne
+	return nil
+}

--- a/schema/types/exec_test.go
+++ b/schema/types/exec_test.go
@@ -1,0 +1,28 @@
+package types
+
+import "testing"
+
+func TestExecValid(t *testing.T) {
+	tests := []Exec{
+		Exec{"/bin/httpd"},
+		Exec{"/app"},
+		Exec{"/app", "arg1", "arg2"},
+	}
+	for i, tt := range tests {
+		if err := tt.assertValid(); err != nil {
+			t.Errorf("#%d: err == %v, want nil", i, err)
+		}
+	}
+}
+
+func TestExecInvalid(t *testing.T) {
+	tests := []Exec{
+		Exec{},
+		Exec{"app"},
+	}
+	for i, tt := range tests {
+		if err := tt.assertValid(); err == nil {
+			t.Errorf("#%d: err == nil, want non-nil", i)
+		}
+	}
+}


### PR DESCRIPTION
`App.Exec` parameters and `EventHandler.Exec` parameters should undergo the
same validation.
