### PR TITLE
spec: remove dependency's "root"

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -459,8 +459,7 @@ JSON Schema for the Image Manifest
                     "name": "env",
                     "val": "canary"
                 }
-            ],
-            "root": "/"
+            ]
         }
     ],
     "pathWhitelist": [

--- a/examples/image.json
+++ b/examples/image.json
@@ -90,8 +90,7 @@
                     "name": "env",
                     "val": "canary"
                 }
-            ],
-            "root": "/"
+            ]
         }
     ],
     "pathWhitelist": [


### PR DESCRIPTION
The example image manifest in the spec and in examples/image.json contain a
dependency's "root" that was removed from the spec.