### PR TITLE
examples: Fix capabilities format in spec.

### DIFF
--- a/examples/image.json
+++ b/examples/image.json
@@ -58,7 +58,7 @@
             },
             {
                 "name": "capabilities/bounding-set",
-                "val": "CAP_NET_BIND_SERVICECAP_SYS_ADMIN"
+                "val": "CAP_NET_BIND_SERVICE CAP_SYS_ADMIN"
             }
         ],
         "mountPoints": [


### PR DESCRIPTION
Adds a missing space between two capabilities.

Signed-off-by: Rohit Jnagal jnagal@google.com