### PR TITLE
spec: change isolators example to list

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -542,7 +542,10 @@ JSON Schema for the Container Runtime Manifest
             "app": "example.com/worker-backup-1.0.0",
             "imageID": "sha512-...",
             "isolators": [
-                {"name": "memory/limit" "val": "1G"}
+                {
+                    "name": "memory/limit",
+                    "val": "1G"
+                }
             ],
             "annotations": {
                 "foo": "baz"
@@ -569,14 +572,12 @@ JSON Schema for the Container Runtime Manifest
             ]
         }
     ],
-
-    "isolators": {
+    "isolators": [
         {
            "name": "memory/limit",
            "value": "4G"
         }
-    },
-
+    ],
     "annotations": {
         "ip-address": "10.1.2.3"
     }


### PR DESCRIPTION
isolators was previously changed to be a list of structs rather than a struct
itself but unfortunately it seems like the actual example embedded in the
SPEC.md was not properly updated (on the other hand, the example JSON is
fine).

h/t @cdaylward