### PR TITLE
discovery: set default version label in doDiscover and not in NewAppFromString

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -22,6 +22,10 @@ type Endpoints struct {
 	Keys []string
 }
 
+const (
+	defaultVersion = "latest"
+)
+
 var (
 	templateExpression = regexp.MustCompile(`{.*?}`)
 )
@@ -95,6 +99,10 @@ func createTemplateVars(app App) []string {
 }
 
 func doDiscover(app App, pre string, insecure bool) (*Endpoints, error) {
+	if app.Labels["version"] == "" {
+		app.Labels["version"] = defaultVersion
+	}
+
 	_, body, err := httpsOrHTTP(pre, insecure)
 	if err != nil {
 		return nil, err

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -126,8 +126,8 @@ func TestDiscoverEndpoints(t *testing.T) {
 			[]string{"https://storage.example.com/example.com/myapp-1.0.0.aci"},
 			[]string{"https://example.com/pubkeys.gpg"},
 		},
-		// Test missing labels. En error should be return as no
-		// ac-discovery templates can be completely rendered.
+		// Test missing labels. version label should default to
+		// "latest" and the first template should be rendered
 		{
 			fakeHTTPGet("myapp2.html", 0),
 			false,
@@ -135,9 +135,9 @@ func TestDiscoverEndpoints(t *testing.T) {
 				Name:   "example.com/myapp",
 				Labels: map[string]string{},
 			},
-			[]string{},
-			[]string{},
-			[]string{},
+			[]string{"https://storage.example.com/example.com/myapp-latest.sig"},
+			[]string{"https://storage.example.com/example.com/myapp-latest.aci"},
+			[]string{"https://example.com/pubkeys.gpg"},
 		},
 		// Test with a label called "name". It should be ignored.
 		{

--- a/discovery/parse.go
+++ b/discovery/parse.go
@@ -3,16 +3,9 @@ package discovery
 import (
 	"fmt"
 	"net/url"
-	"runtime"
 	"strings"
 
 	"github.com/appc/spec/schema/types"
-)
-
-const (
-	defaultVersion = "latest"
-	defaultOS      = runtime.GOOS
-	defaultArch    = runtime.GOARCH
 )
 
 type App struct {
@@ -62,10 +55,6 @@ func NewAppFromString(app string) (*App, error) {
 		}
 		labels[key] = val[0]
 	}
-	if labels["version"] == "" {
-		labels["version"] = defaultVersion
-	}
-
 	a, err := NewApp(name, labels)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is related to #60 and #73. If my thought are wrong please let me know.
If correct probably this should be explained in the spec and maybe also #4 and maybe the app parsing functions should be moved in a new lib outside discovery?

The app and labels serialization format parsed by NewAppFromString is not
strictly related to discovery/fetching but should also be used by other
functions (eg. asking an image to a local store without discovery and fetching).

Setting a default version label if it's missing shouldn't be done here but from
the functions that needs it (now in doDiscover).

