### PR TITLE
acevalidator: fix stderr reference

### DIFF
--- a/ace/validator.go
+++ b/ace/validator.go
@@ -547,3 +547,8 @@ func waitForFile(p string, to time.Duration) []error {
 		}
 	}
 }
+
+func stderr(format string, a ...interface{}) {
+	out := fmt.Sprintf(format, a...)
+	fmt.Fprintln(os.Stderr, strings.TrimSuffix(out, "\n"))
+}


### PR DESCRIPTION
4b128a485bc00687dc8d6f3bcb1adbe6e2c255dd tried to standardise on stderr() but
unfortunately updated the validator to use the function when it's in a
different package; this wasn't caught since we did not have travis confiugred.
For now just introduce the same function to this package.