### PR TITLE
aci: add helper functions for working with ACI images

### DIFF
--- a/aci/file_test.go
+++ b/aci/file_test.go
@@ -1,0 +1,130 @@
+package aci
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func newTestACI() (*os.File, error) {
+	tf, err := ioutil.TempFile("", "")
+	if err != nil {
+		return nil, err
+	}
+
+	manifestBody := `{"acKind":"ImageManifest","acVersion":"0.1.1","name":"example.com/app"}`
+
+	gw := gzip.NewWriter(tf)
+	tw := tar.NewWriter(gw)
+
+	hdr := &tar.Header{
+		Name: "manifest",
+		Size: int64(len(manifestBody)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write([]byte(manifestBody)); err != nil {
+		return nil, err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+	return tf, nil
+}
+
+func newEmptyTestACI() (*os.File, error) {
+	tf, err := ioutil.TempFile("", "")
+	if err != nil {
+		return nil, err
+	}
+	gw := gzip.NewWriter(tf)
+	tw := tar.NewWriter(gw)
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+	return tf, nil
+}
+
+func TestManifestFromImage(t *testing.T) {
+	img, err := newTestACI()
+	if err != nil {
+		t.Fatalf("newTestACI: unexpected error %v", err)
+	}
+	defer img.Close()
+	defer os.Remove(img.Name())
+
+	im, err := ManifestFromImage(img)
+	if err != nil {
+		t.Fatalf("ManifestFromImage: unexpected error %v", err)
+	}
+	if im.Name.String() != "example.com/app" {
+		t.Errorf("expected %s, got %s", "example.com/app", im.Name.String())
+	}
+
+	emptyImg, err := newEmptyTestACI()
+	if err != nil {
+		t.Fatalf("newEmptyTestACI: unexpected error %v", err)
+	}
+	defer emptyImg.Close()
+	defer os.Remove(emptyImg.Name())
+
+	im, err = ManifestFromImage(emptyImg)
+	if err == nil {
+		t.Fatalf("ManifestFromImage: expected error")
+	}
+}
+
+func TestNewCompressedTarReader(t *testing.T) {
+	img, err := newTestACI()
+	if err != nil {
+		t.Fatalf("newTestACI: unexpected error %v", err)
+	}
+	defer img.Close()
+	defer os.Remove(img.Name())
+
+	cr, err := NewCompressedTarReader(img)
+	if err != nil {
+		t.Fatalf("NewCompressedTarReader: unexpected error %v", err)
+	}
+
+	ftype, err := DetectFileType(cr)
+	if err != nil {
+		t.Fatalf("DetectFileType: unexpected error %v", err)
+	}
+
+	if ftype != TypeText {
+		t.Errorf("expected %v, got %v", TypeText, ftype)
+	}
+}
+
+func TestNewCompressedReader(t *testing.T) {
+	img, err := newTestACI()
+	if err != nil {
+		t.Fatalf("newTestACI: unexpected error %v", err)
+	}
+	defer img.Close()
+	defer os.Remove(img.Name())
+
+	cr, err := NewCompressedReader(img)
+	if err != nil {
+		t.Fatalf("NewCompressedReader: unexpected error %v", err)
+	}
+
+	ftype, err := DetectFileType(cr)
+	if err != nil {
+		t.Fatalf("DetectFileType: unexpected error %v", err)
+	}
+
+	if ftype != TypeTar {
+		t.Errorf("expected %v, got %v", TypeTar, ftype)
+	}
+}

--- a/test
+++ b/test
@@ -14,8 +14,8 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE_AND_FORMATTABLE="discovery schema/types"
-FORMATTABLE="$TESTABLE_AND_FORMATTABLE ace aci actool schema pkg/tarheader"
+TESTABLE_AND_FORMATTABLE="aci discovery schema/types"
+FORMATTABLE="$TESTABLE_AND_FORMATTABLE ace actool schema pkg/tarheader"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then


### PR DESCRIPTION
Currently there is no easy way to work with ACI images. Implementations
of the App Container Spec must understand low level details of the ACI
package format in order to complete simple tasks such as extracting
metadata and detecting the type of compression being used.

The ACI package now includes three helper functions for working with ACI
images: ManifestFromImage, NewCompressedTarReader, and NewCompressedReader.