### PR TITLE
discovery: add port parameter

### DIFF
--- a/actool/discover.go
+++ b/actool/discover.go
@@ -13,14 +13,20 @@ var (
 		Name:        "discover",
 		Description: "Discover the download URLs for an app",
 		Summary:     "Discover the download URLs for one or more app container images",
-		Usage:       "APP...",
+		Usage:       "[--http-port PORT] [--https-port PORT] [--insecure] APP...",
 		Run:         runDiscover,
 	}
+	flagHttpPort  uint
+	flagHttpsPort uint
 )
 
 func init() {
 	cmdDiscover.Flags.BoolVar(&transportFlags.Insecure, "insecure", false,
 		"Allow insecure non-TLS downloads over http")
+	cmdDiscover.Flags.UintVar(&flagHttpPort, "http-port", 0,
+		"Port to connect when performing discovery using HTTP. If unset or set to 0, defaults to 80. Sets insecure.")
+	cmdDiscover.Flags.UintVar(&flagHttpsPort, "https-port", 0,
+		"Port to connect when performing discovery HTTPS. If unset or set to 0, defaults to 443.")
 }
 
 func runDiscover(args []string) (exit int) {
@@ -40,7 +46,10 @@ func runDiscover(args []string) (exit int) {
 			stderr("%s: %s", name, err)
 			return 1
 		}
-		eps, attempts, err := discovery.DiscoverEndpoints(*app, transportFlags.Insecure)
+		if flagHttpPort != 0 {
+			transportFlags.Insecure = true
+		}
+		eps, attempts, err := discovery.DiscoverEndpoints(*app, flagHttpPort, flagHttpsPort, transportFlags.Insecure)
 		if err != nil {
 			stderr("error fetching %s: %s", name, err)
 			return 1

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -180,7 +180,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 
 	for i, tt := range tests {
 		httpGet = tt.get
-		de, _, err := DiscoverEndpoints(tt.app, true)
+		de, _, err := DiscoverEndpoints(tt.app, 0, 0, true)
 		if err != nil && !tt.expectDiscoverySuccess {
 			continue
 		}

--- a/discovery/http.go
+++ b/discovery/http.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -31,13 +32,16 @@ func init() {
 	httpGet = c.Get
 }
 
-func httpsOrHTTP(name string, insecure bool) (urlStr string, body io.ReadCloser, err error) {
-	fetch := func(scheme string) (urlStr string, res *http.Response, err error) {
+func httpsOrHTTP(name string, httpPort uint, httpsPort uint, insecure bool) (urlStr string, body io.ReadCloser, err error) {
+	fetch := func(scheme string, port uint) (urlStr string, res *http.Response, err error) {
 		u, err := url.Parse(scheme + "://" + name)
 		if err != nil {
 			return "", nil, err
 		}
 		u.RawQuery = "ac-discovery=1"
+		if port != 0 {
+			u.Host += ":" + strconv.FormatUint(uint64(port), 10)
+		}
 		urlStr = u.String()
 		res, err = httpGet(urlStr)
 		return
@@ -47,11 +51,11 @@ func httpsOrHTTP(name string, insecure bool) (urlStr string, body io.ReadCloser,
 			res.Body.Close()
 		}
 	}
-	urlStr, res, err := fetch("https")
+	urlStr, res, err := fetch("https", httpsPort)
 	if err != nil || res.StatusCode != http.StatusOK {
 		if insecure {
 			closeBody(res)
-			urlStr, res, err = fetch("http")
+			urlStr, res, err = fetch("http", httpPort)
 		}
 	}
 


### PR DESCRIPTION
This allows to perform discovery in arbitrary ports.