### PR TITLE
spec: describe behavior of HTTP redirection during image discovery

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -281,8 +281,10 @@ keys: https://example.com/pubkeys.gpg
 
 This mechanism is only used for discovery of contents URLs.
 
-If the first attempt at fetching the discovery URL returns a status code other than `200 OK` or does not contain any `ac-discovery` meta tags then the next higher path in the name should be tried.
+If the first attempt at fetching the discovery URL returns a status code other than `200 OK`, `3xx`, or does not contain any `ac-discovery` meta tags then the next higher path in the name should be tried.
 For example if the user has `example.com/project/subproject` and we first try `example.com/project/subproject` but don't find a meta tag then try `example.com/project` then try `example.com`.
+
+All HTTP redirects should be followed when the discovery URL returns a `3xx` status code.
 
 Anything implementing this spec should enforce any signing rules set in place by the operator, and ensure the image manifest provided by the fetched ACI are all prefixed from the same domain.
 


### PR DESCRIPTION
Currently the spec does not provided any details regarding the behavior
an implementation should exhibit when an HTTP redirect is encountered
during the image discovery process.

Add clarity by suggesting that HTTP redirects should be followed if
discovery URL returns a 3xx status code.

Fixes #97