### PR TITLE
discovery: implement simple discovery

### DIFF
--- a/actool/discover.go
+++ b/actool/discover.go
@@ -34,15 +34,15 @@ func runDiscover(args []string) (exit int) {
 			return 1
 		}
 		eps, err := discovery.DiscoverEndpoints(*app, transportFlags.Insecure)
-
 		if err != nil {
 			stderr("error fetching %s: %s", name, err)
 			return 1
 		}
-		for _, list := range [][]string{eps.Sig, eps.ACI, eps.Keys} {
-			if len(list) != 0 {
-				fmt.Println(strings.Join(list, ","))
-			}
+		for _, aciEndpoint := range eps.ACIEndpoints {
+			fmt.Println("ACI: %s, Sig: %s\n", aciEndpoint.ACI, aciEndpoint.Sig)
+		}
+		if len(eps.Keys) > 0 {
+			fmt.Println("Keys: " + strings.Join(eps.Keys, ","))
 		}
 	}
 

--- a/actool/discover.go
+++ b/actool/discover.go
@@ -33,10 +33,21 @@ func runDiscover(args []string) (exit int) {
 			stderr("%s: %s", name, err)
 			return 1
 		}
-		eps, err := discovery.DiscoverEndpoints(*app, transportFlags.Insecure)
+		eps := &discovery.Endpoints{}
+		simpleEps, err := discovery.SimpleDiscoverEndpoints(*app, transportFlags.Insecure)
 		if err != nil {
-			stderr("error fetching %s: %s", name, err)
-			return 1
+			stderr("error doing simple discovery for %s: %s", name, err)
+		} else {
+			eps.ACIEndpoints = append(eps.ACIEndpoints, simpleEps.ACIEndpoints...)
+			eps.Keys = append(eps.Keys, simpleEps.Keys...)
+		}
+
+		metaEps, err := discovery.MetaDiscoverEndpoints(*app, transportFlags.Insecure)
+		if err != nil {
+			stderr("error doing matadata discovery for %s: %s", name, err)
+		} else {
+			eps.ACIEndpoints = append(eps.ACIEndpoints, metaEps.ACIEndpoints...)
+			eps.Keys = append(eps.Keys, metaEps.Keys...)
 		}
 		for _, aciEndpoint := range eps.ACIEndpoints {
 			fmt.Println("ACI: %s, Sig: %s\n", aciEndpoint.ACI, aciEndpoint.Sig)

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -16,10 +16,14 @@ type acMeta struct {
 	uri    string
 }
 
+type ACIEndpoint struct {
+	ACI string
+	Sig string
+}
+
 type Endpoints struct {
-	Sig  []string
-	ACI  []string
-	Keys []string
+	ACIEndpoints []ACIEndpoint
+	Keys         []string
 }
 
 const (
@@ -125,20 +129,21 @@ func doDiscover(app App, pre string, insecure bool) (*Endpoints, error) {
 			// Ignore not handled variables as {ext} isn't already rendered.
 			uri, _ := renderTemplate(m.uri, tplVars...)
 			sig, ok := renderTemplate(uri, "{ext}", "sig")
-			if ok {
-				de.Sig = append(de.Sig, sig)
+			if !ok {
+				continue
 			}
 			aci, ok := renderTemplate(uri, "{ext}", "aci")
-			if ok {
-				de.ACI = append(de.ACI, aci)
+			if !ok {
+				continue
 			}
+			de.ACIEndpoints = append(de.ACIEndpoints, ACIEndpoint{ACI: aci, Sig: sig})
 
 		case "ac-discovery-pubkeys":
 			de.Keys = append(de.Keys, m.uri)
 		}
 	}
 
-	if len(de.ACI) == 0 {
+	if len(de.ACIEndpoints) == 0 {
 		return nil, fmt.Errorf("found no ACI meta tags")
 	}
 

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -54,14 +54,17 @@ type httpgetter func(uri string) (*http.Response, error)
 
 func TestDiscoverEndpoints(t *testing.T) {
 	tests := []struct {
-		get                    httpgetter
-		expectDiscoverySuccess bool
-		app                    App
-		expectedACIEndpoints   []ACIEndpoint
-		expectedKeys           []string
+		get                          httpgetter
+		expectSimpleDiscoverySuccess bool
+		expectMetaDiscoverySuccess   bool
+		app                          App
+		expectedSimpleACIEndpoints   []ACIEndpoint
+		expectedMetaACIEndpoints     []ACIEndpoint
+		expectedMetaKeys             []string
 	}{
 		{
 			fakeHTTPGet("myapp.html", 0),
+			true,
 			true,
 			App{
 				Name: "example.com/myapp",
@@ -69,6 +72,16 @@ func TestDiscoverEndpoints(t *testing.T) {
 					"version": "1.0.0",
 					"os":      "linux",
 					"arch":    "amd64",
+				},
+			},
+			[]ACIEndpoint{
+				ACIEndpoint{
+					ACI: "https://example.com/myapp-1.0.0-linux-amd64.aci",
+					Sig: "https://example.com/myapp-1.0.0-linux-amd64.sig",
+				},
+				ACIEndpoint{
+					ACI: "http://example.com/myapp-1.0.0-linux-amd64.aci",
+					Sig: "http://example.com/myapp-1.0.0-linux-amd64.sig",
 				},
 			},
 			[]ACIEndpoint{
@@ -86,12 +99,23 @@ func TestDiscoverEndpoints(t *testing.T) {
 		{
 			fakeHTTPGet("myapp.html", 1),
 			true,
+			true,
 			App{
 				Name: "example.com/myapp/foobar",
 				Labels: map[string]string{
 					"version": "1.0.0",
 					"os":      "linux",
 					"arch":    "amd64",
+				},
+			},
+			[]ACIEndpoint{
+				ACIEndpoint{
+					ACI: "https://example.com/myapp/foobar-1.0.0-linux-amd64.aci",
+					Sig: "https://example.com/myapp/foobar-1.0.0-linux-amd64.sig",
+				},
+				ACIEndpoint{
+					ACI: "http://example.com/myapp/foobar-1.0.0-linux-amd64.aci",
+					Sig: "http://example.com/myapp/foobar-1.0.0-linux-amd64.sig",
 				},
 			},
 			[]ACIEndpoint{
@@ -109,6 +133,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 		{
 			fakeHTTPGet("myapp.html", 20),
 			false,
+			false,
 			App{
 				Name: "example.com/myapp/foobar/bazzer",
 				Labels: map[string]string{
@@ -117,14 +142,62 @@ func TestDiscoverEndpoints(t *testing.T) {
 					"arch":    "amd64",
 				},
 			},
+			[]ACIEndpoint{
+				ACIEndpoint{
+					ACI: "https://example.com/myapp/foobar/bazzer-1.0.0-linux-amd64.aci",
+					Sig: "https://example.com/myapp/foobar/bazzer-1.0.0-linux-amd64.sig",
+				},
+				ACIEndpoint{
+					ACI: "http://example.com/myapp/foobar/bazzer-1.0.0-linux-amd64.aci",
+					Sig: "http://example.com/myapp/foobar/bazzer-1.0.0-linux-amd64.sig",
+				},
+			},
 			[]ACIEndpoint{},
 			[]string{},
 		},
+		// Test with a label called "name". It should be ignored.
+		{
+			fakeHTTPGet("myapp.html", 0),
+			true,
+			true,
+			App{
+				Name: "example.com/myapp",
+				Labels: map[string]string{
+					"name":    "labelcalledname",
+					"version": "1.0.0",
+					"os":      "linux",
+					"arch":    "amd64",
+				},
+			},
+			[]ACIEndpoint{
+				ACIEndpoint{
+					ACI: "https://example.com/myapp-1.0.0-linux-amd64.aci",
+					Sig: "https://example.com/myapp-1.0.0-linux-amd64.sig",
+				},
+				ACIEndpoint{
+					ACI: "http://example.com/myapp-1.0.0-linux-amd64.aci",
+					Sig: "http://example.com/myapp-1.0.0-linux-amd64.sig",
+				},
+			},
+			[]ACIEndpoint{
+				ACIEndpoint{
+					ACI: "https://storage.example.com/example.com/myapp-1.0.0.aci?torrent",
+					Sig: "https://storage.example.com/example.com/myapp-1.0.0.sig?torrent",
+				},
+				ACIEndpoint{
+					ACI: "hdfs://storage.example.com/example.com/myapp-1.0.0.aci",
+					Sig: "hdfs://storage.example.com/example.com/myapp-1.0.0.sig",
+				},
+			},
+			[]string{"https://example.com/pubkeys.gpg"},
+		},
+
 		// Test missing label. Only one ac-discovery template should be
 		// returned as the other one cannot be completely rendered due to
 		// missing labels.
 		{
 			fakeHTTPGet("myapp2.html", 0),
+			false,
 			true,
 			App{
 				Name: "example.com/myapp",
@@ -132,6 +205,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 					"version": "1.0.0",
 				},
 			},
+			[]ACIEndpoint{},
 			[]ACIEndpoint{
 				ACIEndpoint{
 					ACI: "https://storage.example.com/example.com/myapp-1.0.0.aci",
@@ -145,10 +219,12 @@ func TestDiscoverEndpoints(t *testing.T) {
 		{
 			fakeHTTPGet("myapp2.html", 0),
 			false,
+			true,
 			App{
 				Name:   "example.com/myapp",
 				Labels: map[string]string{},
 			},
+			[]ACIEndpoint{},
 			[]ACIEndpoint{
 				ACIEndpoint{
 					ACI: "https://storage.example.com/example.com/myapp-latest.aci",
@@ -157,53 +233,55 @@ func TestDiscoverEndpoints(t *testing.T) {
 			},
 			[]string{"https://example.com/pubkeys.gpg"},
 		},
-		// Test with a label called "name". It should be ignored.
-		{
-			fakeHTTPGet("myapp2.html", 0),
-			false,
-			App{
-				Name: "example.com/myapp",
-				Labels: map[string]string{
-					"name":    "labelcalledname",
-					"version": "1.0.0",
-				},
-			},
-			[]ACIEndpoint{
-				ACIEndpoint{
-					ACI: "https://storage.example.com/example.com/myapp-1.0.0.aci",
-					Sig: "https://storage.example.com/example.com/myapp-1.0.0.sig",
-				},
-			},
-			[]string{"https://example.com/pubkeys.gpg"},
-		},
 	}
 
 	for i, tt := range tests {
-		httpGet = tt.get
-		de, err := DiscoverEndpoints(tt.app, true)
-		if err != nil && !tt.expectDiscoverySuccess {
-			continue
-		}
-		if err != nil {
-			t.Fatalf("#%d DiscoverEndpoints failed: %v", i, err)
-		}
-
-		if len(de.ACIEndpoints) != len(tt.expectedACIEndpoints) {
-			t.Errorf("ACIEndpoints array is wrong length want %d got %d", len(tt.expectedACIEndpoints), len(de.ACIEndpoints))
-		} else {
-			for n, _ := range de.ACIEndpoints {
-				if de.ACIEndpoints[n] != tt.expectedACIEndpoints[n] {
-					t.Errorf("#%d ACIEndpoints[%d] mismatch: want %v got %v", i, n, tt.expectedACIEndpoints[n], de.ACIEndpoints[n])
+		for _, discoveryType := range []string{"simple", "meta"} {
+			var expectedACIEndpoints []ACIEndpoint
+			var expectedKeys []string
+			var de *Endpoints
+			var err error
+			switch discoveryType {
+			case "simple":
+				expectedACIEndpoints = tt.expectedSimpleACIEndpoints
+				expectedKeys = []string{}
+				de, err = SimpleDiscoverEndpoints(tt.app, true)
+				if err != nil && !tt.expectSimpleDiscoverySuccess {
+					continue
+				}
+				if err != nil {
+					t.Fatalf("#%d DiscoverEndpoints failed: %v", i, err)
+				}
+			case "meta":
+				expectedACIEndpoints = tt.expectedMetaACIEndpoints
+				expectedKeys = tt.expectedMetaKeys
+				httpGet = tt.get
+				de, err = MetaDiscoverEndpoints(tt.app, true)
+				if err != nil && !tt.expectMetaDiscoverySuccess {
+					continue
+				}
+				if err != nil {
+					t.Fatalf("#%d DiscoverEndpoints failed: %v", i, err)
 				}
 			}
-		}
 
-		if len(de.Keys) != len(tt.expectedKeys) {
-			t.Errorf("Keys array is wrong length want %d got %d", len(tt.expectedKeys), len(de.Keys))
-		} else {
-			for n, _ := range de.Keys {
-				if de.Keys[n] != tt.expectedKeys[n] {
-					t.Errorf("#%d sig[%d] mismatch: want %v got %v", i, n, tt.expectedKeys[n], de.Keys[n])
+			if len(de.ACIEndpoints) != len(expectedACIEndpoints) {
+				t.Errorf("#%d %s, ACIEndpoints array is wrong length want %d got %d", i, discoveryType, len(expectedACIEndpoints), len(de.ACIEndpoints))
+			} else {
+				for n, _ := range de.ACIEndpoints {
+					if de.ACIEndpoints[n] != expectedACIEndpoints[n] {
+						t.Errorf("#%d %s, ACIEndpoints[%d] mismatch: want %v got %v", i, discoveryType, n, expectedACIEndpoints[n], de.ACIEndpoints[n])
+					}
+				}
+			}
+
+			if len(de.Keys) != len(expectedKeys) {
+				t.Errorf("#%d %s, Keys array is wrong length want %d got %d", i, discoveryType, len(expectedKeys), len(de.Keys))
+			} else {
+				for n, _ := range de.Keys {
+					if de.Keys[n] != expectedKeys[n] {
+						t.Errorf("#%d %s, Key[%d] mismatch: want %v got %v", i, discoveryType, n, expectedKeys[n], de.Keys[n])
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This patch needs coreos/rocket#382 implemented in rocket (or fetch will fail as it will use only the first simple discovery url).

When applied, as it changes the name of DiscoverEndpoints to MetaDiscoverEndpoints, rocket should be changed to handle this different name (in rkt/fetch.go, done in coreos/rocket#383)

Implement simple discovery as defined in the spec.
If insecure is true, also the http scheme, in addition to https is used to
render the simple template.
This adds a new function for simple discovery so users can separately
call Simple and Meta discovery (and get per discovery type errors).
Fix and improve tests.