### PR TITLE
Fix Annotations.Set()

### DIFF
--- a/schema/container.go
+++ b/schema/container.go
@@ -75,3 +75,11 @@ type RuntimeApp struct {
 	Isolators   []types.Isolator  `json:"isolators"`
 	Annotations types.Annotations `json:"annotations"`
 }
+
+func (app *RuntimeApp) GetAnnotation(name string) (val string, ok bool) {
+	return app.Annotations.Get(name)
+}
+
+func (app *RuntimeApp) SetAnnotation(name types.ACName, value string) {
+	app.Annotations = app.Annotations.Set(name, value)
+}

--- a/schema/image.go
+++ b/schema/image.go
@@ -72,3 +72,7 @@ func (im *ImageManifest) GetLabel(name string) (val string, ok bool) {
 func (im *ImageManifest) GetAnnotation(name string) (val string, ok bool) {
 	return im.Annotations.Get(name)
 }
+
+func (im *ImageManifest) SetAnnotation(name types.ACName, value string) {
+	im.Annotations = im.Annotations.Set(name, value)
+}

--- a/schema/types/annotations.go
+++ b/schema/types/annotations.go
@@ -74,16 +74,16 @@ func (a Annotations) Get(name string) (val string, ok bool) {
 }
 
 // Set sets the value of an annotation by the given name, overwriting if one already exists.
-func (a Annotations) Set(name ACName, value string) {
+func (a Annotations) Set(name ACName, value string) Annotations {
 	for _, anno := range a {
 		if anno.Name.Equals(name) {
 			anno.Value = value
-			return
+			return a
 		}
 	}
 	anno := Annotation{
 		Name:  name,
 		Value: value,
 	}
-	a = append(a, anno)
+	return append(a, anno)
 }


### PR DESCRIPTION
`Annotations.Set` has been `append()`ing new Annotation to a private copy of the slice, which had effect only inside the `Set` function, unless `Annotations`' capacity has been greater than its length. This causes inconsistent behaviour, and – in most cases – no visible effect of setting a new annotation. If `Annotations.Set` behaves like `append` that it uses – i.e. returns an updated slice – the caller is able to replace old annotations slice with the updated one.
Second commit `SetAnnotation` methods on `ImageManifest` and `RuntimeApp`, to make `Annotations.Set` more useful, and `GetAnnotation` on `RuntimeApp` for consistency.