### PR TITLE
types: fix annotations Set method

### DIFF
--- a/schema/types/annotations.go
+++ b/schema/types/annotations.go
@@ -74,10 +74,13 @@ func (a Annotations) Get(name string) (val string, ok bool) {
 }
 
 // Set sets the value of an annotation by the given name, overwriting if one already exists.
-func (a Annotations) Set(name ACName, value string) {
-	for _, anno := range a {
+func (a *Annotations) Set(name ACName, value string) {
+	for i, anno := range *a {
 		if anno.Name.Equals(name) {
-			anno.Value = value
+			(*a)[i] = Annotation{
+				Name:  name,
+				Value: value,
+			}
 			return
 		}
 	}
@@ -85,5 +88,5 @@ func (a Annotations) Set(name ACName, value string) {
 		Name:  name,
 		Value: value,
 	}
-	a = append(a, anno)
+	*a = append(*a, anno)
 }

--- a/schema/types/annotations_test.go
+++ b/schema/types/annotations_test.go
@@ -1,6 +1,9 @@
 package types
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func makeAnno(n, v string) Annotation {
 	name, err := NewACName(n)
@@ -74,5 +77,35 @@ func TestAnnotationsAssertValid(t *testing.T) {
 		if gerr := (err != nil); gerr != tt.werr {
 			t.Errorf("#%d: gerr=%t, want %t (err=%v)", i, gerr, tt.werr, err)
 		}
+	}
+}
+
+func TestAnnotationsSet(t *testing.T) {
+	a := Annotations{}
+
+	a.Set("foo", "bar")
+	w := Annotations{
+		Annotation{ACName("foo"), "bar"},
+	}
+	if !reflect.DeepEqual(w, a) {
+		t.Fatalf("want %v, got %v", w, a)
+	}
+
+	a.Set("dog", "woof")
+	w = Annotations{
+		Annotation{ACName("foo"), "bar"},
+		Annotation{ACName("dog"), "woof"},
+	}
+	if !reflect.DeepEqual(w, a) {
+		t.Fatalf("want %v, got %v", w, a)
+	}
+
+	a.Set("foo", "baz")
+	w = Annotations{
+		Annotation{ACName("foo"), "baz"},
+		Annotation{ACName("dog"), "woof"},
+	}
+	if !reflect.DeepEqual(w, a) {
+		t.Fatalf("want %v, got %v", w, a)
 	}
 }


### PR DESCRIPTION
Set was acting on an Annotations value instead of a pointer, which is never 
going to work for obvious reasons. This changes the receiver to a pointer and
corrects the logic to properly set the value in-place if necessary.

Also adds a test case for Annotations.Set which should have been there all
along and catches this issue.

Thanks to @mpasternacki for catching this silliness.