### PR TITLE
tarheader: correctly set major/minor on /dev files

### DIFF
--- a/pkg/tarheader/pop_posix.go
+++ b/pkg/tarheader/pop_posix.go
@@ -17,6 +17,11 @@ func populateHeaderUnix(h *tar.Header, fi os.FileInfo, seen map[uint64]string) {
 	}
 	h.Uid = int(st.Uid)
 	h.Gid = int(st.Gid)
+	if st.Mode&syscall.S_IFMT == syscall.S_IFBLK || st.Mode&syscall.S_IFMT == syscall.S_IFCHR {
+		// FIXME: it would be better to use the C macros: major(3), minor(3)
+		h.Devminor = int64(st.Rdev & 0xff)
+		h.Devmajor = int64((st.Rdev >> 8) & 0xfff)
+	}
 	// If we have already seen this inode, generate a hardlink
 	p, ok := seen[uint64(st.Ino)]
 	if ok {


### PR DESCRIPTION
This fix would help with flanneld using /dev/net/tun.
See https://github.com/coreos/rocket/issues/389
