### PR TITLE
schema: don't discard existing data when unmarshaling complex structures

### DIFF
--- a/schema/container.go
+++ b/schema/container.go
@@ -7,6 +7,8 @@ import (
 	"github.com/appc/spec/schema/types"
 )
 
+const ContainerRuntimeManifestKind = types.ACKind("ContainerRuntimeManifest")
+
 type ContainerRuntimeManifest struct {
 	ACVersion   types.SemVer      `json:"acVersion"`
 	ACKind      types.ACKind      `json:"acKind"`
@@ -20,6 +22,8 @@ type ContainerRuntimeManifest struct {
 // containerRuntimeManifest is a model to facilitate extra validation during the
 // unmarshalling of the ContainerRuntimeManifest
 type containerRuntimeManifest ContainerRuntimeManifest
+
+var BlankContainerRuntimeManifest = ContainerRuntimeManifest{ACKind: ContainerRuntimeManifestKind}
 
 func (cm *ContainerRuntimeManifest) UnmarshalJSON(data []byte) error {
 	c := containerRuntimeManifest{}
@@ -42,14 +46,16 @@ func (cm ContainerRuntimeManifest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(containerRuntimeManifest(cm))
 }
 
+var cmKindError = types.InvalidACKindError(ContainerRuntimeManifestKind)
+
 // assertValid performs extra assertions on an ContainerRuntimeManifest to
 // ensure that fields are set appropriately, etc. It is used exclusively when
 // marshalling and unmarshalling an ContainerRuntimeManifest. Most
 // field-specific validation is performed through the individual types being
 // marshalled; assertValid() should only deal with higher-level validation.
 func (cm *ContainerRuntimeManifest) assertValid() error {
-	if cm.ACKind != "ContainerRuntimeManifest" {
-		return types.ACKindError(`missing or bad ACKind (must be "ContainerRuntimeManifest")`)
+	if cm.ACKind != ContainerRuntimeManifestKind {
+		return cmKindError
 	}
 	return nil
 }

--- a/schema/container.go
+++ b/schema/container.go
@@ -26,7 +26,7 @@ type containerRuntimeManifest ContainerRuntimeManifest
 var BlankContainerRuntimeManifest = ContainerRuntimeManifest{ACKind: ContainerRuntimeManifestKind}
 
 func (cm *ContainerRuntimeManifest) UnmarshalJSON(data []byte) error {
-	c := containerRuntimeManifest{}
+	c := containerRuntimeManifest(*cm)
 	err := json.Unmarshal(data, &c)
 	if err != nil {
 		return err

--- a/schema/container.go
+++ b/schema/container.go
@@ -23,7 +23,9 @@ type ContainerRuntimeManifest struct {
 // unmarshalling of the ContainerRuntimeManifest
 type containerRuntimeManifest ContainerRuntimeManifest
 
-var BlankContainerRuntimeManifest = ContainerRuntimeManifest{ACKind: ContainerRuntimeManifestKind}
+func BlankContainerRuntimeManifest() *ContainerRuntimeManifest {
+	return &ContainerRuntimeManifest{ACKind: ContainerRuntimeManifestKind, ACVersion: AppContainerVersion}
+}
 
 func (cm *ContainerRuntimeManifest) UnmarshalJSON(data []byte) error {
 	c := containerRuntimeManifest(*cm)

--- a/schema/container_test.go
+++ b/schema/container_test.go
@@ -1,0 +1,19 @@
+package schema
+
+import "testing"
+
+func TestContainerRuntimeManifestMerge(t *testing.T) {
+	cmj := `{}`
+	cm := &ContainerRuntimeManifest{}
+
+	if cm.UnmarshalJSON([]byte(cmj)) == nil {
+		t.Fatal("Manifest JSON without acKind and acVersion unmarshalled successfully")
+	}
+
+	cm = BlankContainerRuntimeManifest()
+
+	err := cm.UnmarshalJSON([]byte(cmj))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/schema/image.go
+++ b/schema/image.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	ACIExtension = ".aci"
+	ACIExtension      = ".aci"
+	ImageManifestKind = types.ACKind("ImageManifest")
 )
 
 type ImageManifest struct {
@@ -25,6 +26,8 @@ type ImageManifest struct {
 // imageManifest is a model to facilitate extra validation during the
 // unmarshalling of the ImageManifest
 type imageManifest ImageManifest
+
+var BlankImageManifest = ImageManifest{ACKind: ImageManifestKind}
 
 func (im *ImageManifest) UnmarshalJSON(data []byte) error {
 	a := imageManifest{}
@@ -47,14 +50,16 @@ func (im ImageManifest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(imageManifest(im))
 }
 
+var imKindError = types.InvalidACKindError(ImageManifestKind)
+
 // assertValid performs extra assertions on an ImageManifest to ensure that
 // fields are set appropriately, etc. It is used exclusively when marshalling
 // and unmarshalling an ImageManifest. Most field-specific validation is
 // performed through the individual types being marshalled; assertValid()
 // should only deal with higher-level validation.
 func (im *ImageManifest) assertValid() error {
-	if im.ACKind != "ImageManifest" {
-		return types.ACKindError(`missing or bad ACKind (must be "ImageManifest")`)
+	if im.ACKind != ImageManifestKind {
+		return imKindError
 	}
 	if im.ACVersion.Empty() {
 		return errors.New(`acVersion must be set`)

--- a/schema/image.go
+++ b/schema/image.go
@@ -30,7 +30,7 @@ type imageManifest ImageManifest
 var BlankImageManifest = ImageManifest{ACKind: ImageManifestKind}
 
 func (im *ImageManifest) UnmarshalJSON(data []byte) error {
-	a := imageManifest{}
+	a := imageManifest(*im)
 	err := json.Unmarshal(data, &a)
 	if err != nil {
 		return err

--- a/schema/image.go
+++ b/schema/image.go
@@ -27,7 +27,9 @@ type ImageManifest struct {
 // unmarshalling of the ImageManifest
 type imageManifest ImageManifest
 
-var BlankImageManifest = ImageManifest{ACKind: ImageManifestKind}
+func BlankImageManifest() *ImageManifest {
+	return &ImageManifest{ACKind: ImageManifestKind, ACVersion: AppContainerVersion}
+}
 
 func (im *ImageManifest) UnmarshalJSON(data []byte) error {
 	a := imageManifest(*im)

--- a/schema/image_test.go
+++ b/schema/image_test.go
@@ -33,13 +33,13 @@ func TestEmptyApp(t *testing.T) {
 
 func TestImageManifestMerge(t *testing.T) {
 	imj := `{"name": "example.com/test"}`
-	var im ImageManifest
+	im := &ImageManifest{}
 
 	if im.UnmarshalJSON([]byte(imj)) == nil {
 		t.Fatal("Manifest JSON without acKind and acVersion unmarshalled successfully")
 	}
 
-	im = BlankImageManifest
+	im = BlankImageManifest()
 
 	err := im.UnmarshalJSON([]byte(imj))
 	if err != nil {

--- a/schema/image_test.go
+++ b/schema/image_test.go
@@ -30,3 +30,19 @@ func TestEmptyApp(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestImageManifestMerge(t *testing.T) {
+	imj := `{"name": "example.com/test"}`
+	var im ImageManifest
+
+	if im.UnmarshalJSON([]byte(imj)) == nil {
+		t.Fatal("Manifest JSON without acKind and acVersion unmarshalled successfully")
+	}
+
+	im = BlankImageManifest
+
+	err := im.UnmarshalJSON([]byte(imj))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/schema/types/app.go
+++ b/schema/types/app.go
@@ -24,7 +24,7 @@ type App struct {
 type app App
 
 func (a *App) UnmarshalJSON(data []byte) error {
-	ja := app{}
+	ja := app(*a)
 	err := json.Unmarshal(data, &ja)
 	if err != nil {
 		return err

--- a/schema/types/errors.go
+++ b/schema/types/errors.go
@@ -1,10 +1,16 @@
 package types
 
+import "fmt"
+
 // An ACKindError is returned when the wrong ACKind is set in a manifest
 type ACKindError string
 
 func (e ACKindError) Error() string {
 	return string(e)
+}
+
+func InvalidACKindError(kind ACKind) ACKindError {
+	return ACKindError(fmt.Sprintf("missing or bad ACKind (must be %#v)", kind))
 }
 
 // An ACVersionError is returned when a bad ACVersion is set in a manifest

--- a/schema/version.go
+++ b/schema/version.go
@@ -22,6 +22,4 @@ func init() {
 		panic(err)
 	}
 	AppContainerVersion = *v
-	BlankImageManifest.ACVersion = AppContainerVersion
-	BlankContainerRuntimeManifest.ACVersion = AppContainerVersion
 }

--- a/schema/version.go
+++ b/schema/version.go
@@ -22,4 +22,6 @@ func init() {
 		panic(err)
 	}
 	AppContainerVersion = *v
+	BlankImageManifest.ACVersion = AppContainerVersion
+	BlankContainerRuntimeManifest.ACVersion = AppContainerVersion
 }


### PR DESCRIPTION
These changes make it easier to programmatically construct and modify manifests.

Would it be a good idea to take that further and allow "delta JSON" for slice types (Annotations, Labels, etc): JSON unmarshaled on top of existing slice would then:
- add new element if it doesn't exist
- update existing element if there is one
- delete existing element on some marker (nil value? empty string value? special attribute that wouldn't make it into final manifest?)