### PR TITLE
schema: Clarify kind, source, and readOnly for image manifest volumes.

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -623,7 +623,9 @@ JSON Schema for the Container Runtime Manifest (container manifest)
     * **isolators** (optional) list of isolators that should be applied to this app (key is restricted to the AC Name formatting and the value can be a freeform string)
     * **annotations** (optional) arbitrary metadata appended to the app. Should be a list of annotation objects (where the *name* is restricted to the [AC Name](#ac-name-type) formatting and *value* is an arbitrary string). Annotation names must be unique within the list. These will be merged with annotations provided by the image manifest when queried via the metadata service; values in this list take precedence over those in the image manifest.
 * **volumes** (optional) list of volumes which should be mounted into each application's filesystem
-    * **kind** (required) string, currently either "empty" or "host" (bind mount)
+    * **kind** (required) either "empty" or "host". "empty" fulfills a mount point by ensuring the path exists (writes go to container). "host" fulfills a mount point with a bind mount from a **source**.
+    * **source** (required if **kind** is "host") absolute path on host to be bind mounted into the container under a mount point.
+    * **readOnly** (optional if **kind** is "host") whether or not the volume should be mounted read only.
     * **fulfills** (required) MountPoints of the containers that this volume can fulfill (string, restricted to AC Name formatting)
 * **isolators** (optional) list of isolators that will apply to all apps in this container (name is restricted to the AC Name formatting and the value can be a freeform string)
 * **annotations** (optional) arbitrary metadata the executor should make available to applications via the metadata service. Should be a list of annotation objects (where the *name* is restricted to the [AC Name](#ac-name-type) formatting and *value* is an arbitrary string). Annotation names must be unique within the list.


### PR DESCRIPTION
Made the follow modifications to the spec based on my extrapolation of what the **volumes** fields meant.

- Clarify what should occur based on kind.
- Add missing definition for source.
- Add missing definition for readOnly.