### PR TITLE
discovery: Tie together ACI and Sig URLs.

### DIFF
--- a/actool/discover.go
+++ b/actool/discover.go
@@ -34,15 +34,15 @@ func runDiscover(args []string) (exit int) {
 			return 1
 		}
 		eps, err := discovery.DiscoverEndpoints(*app, transportFlags.Insecure)
-
 		if err != nil {
 			stderr("error fetching %s: %s", name, err)
 			return 1
 		}
-		for _, list := range [][]string{eps.Sig, eps.ACI, eps.Keys} {
-			if len(list) != 0 {
-				fmt.Println(strings.Join(list, ","))
-			}
+		for _, aciEndpoint := range eps.ACIEndpoints {
+			fmt.Println("ACI: %s, Sig: %s\n", aciEndpoint.ACI, aciEndpoint.Sig)
+		}
+		if len(eps.Keys) > 0 {
+			fmt.Println("Keys: " + strings.Join(eps.Keys, ","))
 		}
 	}
 

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -16,10 +16,14 @@ type acMeta struct {
 	uri    string
 }
 
+type ACIEndpoint struct {
+	ACI string
+	Sig string
+}
+
 type Endpoints struct {
-	Sig  []string
-	ACI  []string
-	Keys []string
+	ACIEndpoints []ACIEndpoint
+	Keys         []string
 }
 
 const (
@@ -125,20 +129,21 @@ func doDiscover(app App, pre string, insecure bool) (*Endpoints, error) {
 			// Ignore not handled variables as {ext} isn't already rendered.
 			uri, _ := renderTemplate(m.uri, tplVars...)
 			sig, ok := renderTemplate(uri, "{ext}", "sig")
-			if ok {
-				de.Sig = append(de.Sig, sig)
+			if !ok {
+				continue
 			}
 			aci, ok := renderTemplate(uri, "{ext}", "aci")
-			if ok {
-				de.ACI = append(de.ACI, aci)
+			if !ok {
+				continue
 			}
+			de.ACIEndpoints = append(de.ACIEndpoints, ACIEndpoint{ACI: aci, Sig: sig})
 
 		case "ac-discovery-pubkeys":
 			de.Keys = append(de.Keys, m.uri)
 		}
 	}
 
-	if len(de.ACI) == 0 {
+	if len(de.ACIEndpoints) == 0 {
 		return nil, fmt.Errorf("found no ACI meta tags")
 	}
 


### PR DESCRIPTION
This patch, should be merged together with the rocket part (coreos/rocket#398).

As the aci urls is tied with its signature url, to avoid confusion, tie them
together in their own struct.