### PR TITLE
aci/actool: remove superfluous AddFile argument

### DIFF
--- a/aci/writer.go
+++ b/aci/writer.go
@@ -14,7 +14,7 @@ import (
 // should create an ArchiveWriter and add files to it; the ACI will be written
 // to the underlying tar.Writer
 type ArchiveWriter interface {
-	AddFile(path string, hdr *tar.Header, r io.Reader) error
+	AddFile(hdr *tar.Header, r io.Reader) error
 	Close() error
 }
 
@@ -34,7 +34,7 @@ func NewImageWriter(am schema.ImageManifest, w *tar.Writer) ArchiveWriter {
 	return aw
 }
 
-func (aw *imageArchiveWriter) AddFile(path string, hdr *tar.Header, r io.Reader) error {
+func (aw *imageArchiveWriter) AddFile(hdr *tar.Header, r io.Reader) error {
 	err := aw.Writer.WriteHeader(hdr)
 	if err != nil {
 		return err
@@ -65,7 +65,7 @@ func (aw *imageArchiveWriter) addFileNow(path string, contents []byte) error {
 		Gname:      "root",
 		ChangeTime: now,
 	}
-	return aw.AddFile(path, &hdr, buf)
+	return aw.AddFile(&hdr, buf)
 }
 
 func (aw *imageArchiveWriter) addManifest(name string, m json.Marshaler) error {

--- a/actool/build.go
+++ b/actool/build.go
@@ -90,7 +90,7 @@ func buildWalker(root string, aw aci.ArchiveWriter) filepath.WalkFunc {
 			hdr.Size = 0
 			r = nil
 		}
-		if err := aw.AddFile(relpath, hdr, r); err != nil {
+		if err := aw.AddFile(hdr, r); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
At some point in the past, AddFile relied on the path to be explicitly passed
in, but now it simply uses the path that is set on the tar header it is
passed, so we can remove the argument now.