### PR TITLE
schema: Modify App Environment to be a list of name/value objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ tar xf /tmp/my-app.aci manifest -O | python -m json.tool
     "acVersion": "0.2.0",
     "annotations": null,
     "app": {
-        "environment": {},
+        "environment": [],
         "eventHandlers": null,
         "exec": [
             "/bin/my-app"

--- a/SPEC.md
+++ b/SPEC.md
@@ -419,9 +419,12 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest)
             }
         ],
         "workingDirectory": "/opt/work",
-        "environment": {
-            "REDUCE_WORKER_DEBUG": "true"
-        },
+        "environment": [
+            {
+                "name": "REDUCE_WORKER_DEBUG",
+                "value": "true"
+            }
+        ],
         "isolators": [
             {
                 "name": "private-network",
@@ -517,7 +520,7 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest)
         * **pre-start** - executed and must exit before the long running main **exec** binary is launched
         * **post-stop** - executed if the main **exec** process is killed. This can be used to cleanup resources in the case of clean application shutdown, but cannot be relied upon in the face of machine failure.
     * **workingDirectory** (optional) working directory of the launched application, relative to the application image's root (must be an absolute path, defaults to "/", ACE can override). If the directory does not exist in the application's assembled rootfs (including any dependent images and mounted volumes), the ACE must fail execution.
-    * **environment** (optional) app's preferred environment variables (map of freeform strings) (ACE can append)
+    * **environment** (optional) a list of name / value objects representing the app's environment variables (ACE can append). The **name** must consist solely of letters, digits, and underscores '_' as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
     * **mountPoints** (optional) locations where a container is expecting external data to be mounted. The name indicates an executor-defined label to look up a mount point, and the path stipulates where it should actually be mounted inside the rootfs. The name is restricted to the AC Name Type formatting. "readOnly" should be a boolean indicating whether or not the mount point should be read-only (defaults to "false" if unsupplied).
     * **ports** (optional) protocols and port numbers that the container will be listening on once started. The key is restricted to the AC Name formatting. This information is primarily informational to help the user find ports that are not well known. It could also optionally be used to limit the inbound connections to the container via firewall rules to only ports that are explicitly exposed.
         * **socketActivated** (optional) if set to true, the application expects to be [socket activated](http://www.freedesktop.org/software/systemd/man/sd_listen_fds.html) on these ports. The ACE must pass file descriptors using the [socket activation protocol](http://www.freedesktop.org/software/systemd/man/sd_listen_fds.html) that are listening on these ports when starting this container. If multiple apps in the same container are using socket activation then the ACE must match the sockets to the correct apps using getsockopt() and getsockname().

--- a/ace/image_manifest_main.json
+++ b/ace/image_manifest_main.json
@@ -28,9 +28,12 @@
         "user": "0",
         "group": "0",
         "workingDirectory": "/opt/acvalidator",
-        "environment": {
-            "IN_ACE_VALIDATOR": "correct"
-        },
+        "environment": [
+            {
+                "name": "IN_ACE_VALIDATOR",
+                "value": "correct"
+            }
+        ],
         "mountPoints": [
             {
                 "name": "database",

--- a/examples/image.json
+++ b/examples/image.json
@@ -36,9 +36,12 @@
                 "name": "post-stop"
             }
         ],
-        "environment": {
-            "REDUCE_WORKER_DEBUG": "true"
-        },
+        "environment": [
+            {
+                "name": "REDUCE_WORKER_DEBUG",
+                "value": "true"
+            }
+        ],
         "isolators": [
             {
                 "name": "private-network",

--- a/schema/types/app.go
+++ b/schema/types/app.go
@@ -8,15 +8,15 @@ import (
 )
 
 type App struct {
-	Exec             Exec              `json:"exec"`
-	EventHandlers    []EventHandler    `json:"eventHandlers,omitempty"`
-	User             string            `json:"user"`
-	Group            string            `json:"group"`
-	WorkingDirectory string            `json:"workingDirectory,omitempty"`
-	Environment      map[string]string `json:"environment,omitempty"`
-	MountPoints      []MountPoint      `json:"mountPoints,omitempty"`
-	Ports            []Port            `json:"ports,omitempty"`
-	Isolators        []Isolator        `json:"isolators,omitempty"`
+	Exec             Exec           `json:"exec"`
+	EventHandlers    []EventHandler `json:"eventHandlers,omitempty"`
+	User             string         `json:"user"`
+	Group            string         `json:"group"`
+	WorkingDirectory string         `json:"workingDirectory,omitempty"`
+	Environment      Environment    `json:"environment,omitempty"`
+	MountPoints      []MountPoint   `json:"mountPoints,omitempty"`
+	Ports            []Port         `json:"ports,omitempty"`
+	Isolators        []Isolator     `json:"isolators,omitempty"`
 }
 
 // app is a model to facilitate extra validation during the
@@ -34,7 +34,7 @@ func (a *App) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if na.Environment == nil {
-		na.Environment = make(map[string]string)
+		na.Environment = make(Environment, 0)
 	}
 	*a = na
 	return nil
@@ -67,6 +67,9 @@ func (a *App) assertValid() error {
 			return fmt.Errorf("Only one eventHandler of name %q allowed", name)
 		}
 		eh[name] = true
+	}
+	if err := a.Environment.assertValid(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/schema/types/app_test.go
+++ b/schema/types/app_test.go
@@ -18,6 +18,9 @@ func TestAppValid(t *testing.T) {
 				{Name: "pre-start"},
 				{Name: "post-stop"},
 			},
+			Environment: []EnvironmentVariable{
+				{Name: "DEBUG", Value: "true"},
+			},
 			WorkingDirectory: "/tmp",
 		},
 		App{
@@ -126,6 +129,21 @@ func TestAppWorkingDirectoryInvalid(t *testing.T) {
 	tests := []App{
 		App{
 			WorkingDirectory: "stuff",
+		},
+	}
+	for i, tt := range tests {
+		if err := tt.assertValid(); err == nil {
+			t.Errorf("#%d: err == nil, want non-nil", i)
+		}
+	}
+}
+
+func TestAppEnvironmentInvalid(t *testing.T) {
+	tests := []App{
+		App{
+			Environment: Environment{
+				EnvironmentVariable{"0DEBUG", "true"},
+			},
 		},
 	}
 	for i, tt := range tests {

--- a/schema/types/environment.go
+++ b/schema/types/environment.go
@@ -1,0 +1,96 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+var (
+	envPattern = regexp.MustCompile("^[A-Za-z_][A-Za-z_0-9]*$")
+)
+
+type Environment []EnvironmentVariable
+
+type environment Environment
+
+type EnvironmentVariable struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func (ev EnvironmentVariable) assertValid() error {
+	if len(ev.Name) == 0 {
+		return fmt.Errorf(`environment variable name must not be empty`)
+	}
+	if !envPattern.MatchString(ev.Name) {
+		return fmt.Errorf(`environment variable does not have valid identifier %q`, ev.Name)
+	}
+	return nil
+}
+
+func (e Environment) assertValid() error {
+	seen := map[string]bool{}
+	for _, env := range e {
+		if err := env.assertValid(); err != nil {
+			return err
+		}
+		_, ok := seen[env.Name]
+		if ok {
+			return fmt.Errorf(`duplicate environment variable of name %q`, env.Name)
+		}
+		seen[env.Name] = true
+	}
+
+	return nil
+}
+
+func (e Environment) MarshalJSON() ([]byte, error) {
+	if err := e.assertValid(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(environment(e))
+}
+
+func (e *Environment) UnmarshalJSON(data []byte) error {
+	var je environment
+	if err := json.Unmarshal(data, &je); err != nil {
+		return err
+	}
+	ne := Environment(je)
+	if err := ne.assertValid(); err != nil {
+		return err
+	}
+	*e = ne
+	return nil
+}
+
+// Retrieve the value of an environment variable by the given name from
+// Environment, if it exists.
+func (e Environment) Get(name string) (value string, ok bool) {
+	for _, env := range e {
+		if env.Name == name {
+			return env.Value, true
+		}
+	}
+	return "", false
+}
+
+// Set sets the value of an environment variable by the given name,
+// overwriting if one already exists.
+func (e *Environment) Set(name string, value string) {
+	for i, env := range *e {
+		if env.Name == name {
+			(*e)[i] = EnvironmentVariable{
+				Name:  name,
+				Value: value,
+			}
+			return
+		}
+	}
+	env := EnvironmentVariable{
+		Name:  name,
+		Value: value,
+	}
+	*e = append(*e, env)
+}

--- a/schema/types/environment_test.go
+++ b/schema/types/environment_test.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestEnvironmentAssertValid(t *testing.T) {
+	tests := []struct {
+		env  Environment
+		werr bool
+	}{
+		// duplicate names should fail
+		{
+			Environment{
+				EnvironmentVariable{"DEBUG", "true"},
+				EnvironmentVariable{"DEBUG", "true"},
+			},
+			true,
+		},
+		// empty name should fail
+		{
+			Environment{
+				EnvironmentVariable{"", "value"},
+			},
+			true,
+		},
+		// name beginning with digit should fail
+		{
+			Environment{
+				EnvironmentVariable{"0DEBUG", "true"},
+			},
+			true,
+		},
+		// name with non [A-Za-z0-9_] should fail
+		{
+			Environment{
+				EnvironmentVariable{"VERBOSE-DEBUG", "true"},
+			},
+			true,
+		},
+		// accepted environment variable forms
+		{
+			Environment{
+				EnvironmentVariable{"DEBUG", "true"},
+			},
+			false,
+		},
+		{
+			Environment{
+				EnvironmentVariable{"_0_DEBUG_0_", "true"},
+			},
+			false,
+		},
+	}
+	for i, test := range tests {
+		env := Environment(test.env)
+		err := env.assertValid()
+		if gerr := (err != nil); gerr != test.werr {
+			t.Errorf("#%d: gerr=%t, want %t (err=%v)", i, gerr, test.werr, err)
+		}
+	}
+}


### PR DESCRIPTION
Make environment consistent with isolators and annotations (schema on "left", user values on "right", etc).

- Add EnvironmentVariable type.
- Add Environment alias for list of EnvironmentVariables
- Replace App.Environment field with new Environment type
- Plumb App.assertValid through to Environment.assertValid()
- Call out and test for IEEE Std 1003.1-2001 in environment variable
  identifiers.