### PR TITLE
SPEC: add mountPoints and remove fulfills

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -449,8 +449,8 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest)
         ],
         "mountPoints": [
             {
-                "name": "database",
-                "path": "/var/lib/db",
+                "name": "work",
+                "path": "/var/lib/work",
                 "readOnly": false
             }
         ],
@@ -565,7 +565,10 @@ JSON Schema for the Container Runtime Manifest (container manifest)
     "apps": [
         {
             "app": "example.com/reduce-worker-1.0.0",
-            "imageID": "sha512-..."
+            "imageID": "sha512-...",
+            "mounts": [
+                 {"volume": "work", "mountPoint": "work"}
+            ]
         },
         {
             "app": "example.com/worker-backup-1.0.0",
@@ -579,6 +582,9 @@ JSON Schema for the Container Runtime Manifest (container manifest)
             "annotations": [
                 "name": "foo",
                 "value": "baz"
+            },
+            "mounts": [
+                 {"volume": "work", "mountPoint": "backup"}
             ]
         },
         {
@@ -588,18 +594,10 @@ JSON Schema for the Container Runtime Manifest (container manifest)
     ],
     "volumes": [
         {
+            "name": "work",
             "kind": "host",
             "source": "/opt/tenant1/work",
-            "readOnly": true,
-            "fulfills": [
-                "work"
-            ]
-        },
-        {
-            "kind": "empty",
-            "fulfills": [
-                "buildOutput"
-            ]
+            "readOnly": true
         }
     ],
     "isolators": [
@@ -623,9 +621,13 @@ JSON Schema for the Container Runtime Manifest (container manifest)
 * **apps** (required) list of apps that will execute inside of this container
     * **app** (optional) name of the app (string, restricted to AC Name formatting)
     * **imageID** (required) content hash of the image that this app will execute inside of (string, must be of the format "type-value", where "type" is "sha512" and value is the hex encoded string of the hash)
+    * **mounts** (optional) list of mounts mapping an app mountPoint to a volume
+      * **volume** name of the volume that will fulfill this mount (string, restricted to the AC Name formatting)
+      * **mountPoint** the name of the app mount point to place the volume on (string, restricted to the AC Name formatting)
     * **isolators** (optional) list of isolators that should be applied to this app (key is restricted to the AC Name formatting and the value can be a freeform string)
     * **annotations** (optional) arbitrary metadata appended to the app. Should be a list of annotation objects (where the *name* is restricted to the [AC Name](#ac-name-type) formatting and *value* is an arbitrary string). Annotation names must be unique within the list. These will be merged with annotations provided by the image manifest when queried via the metadata service; values in this list take precedence over those in the image manifest.
 * **volumes** (optional) list of volumes which should be mounted into each application's filesystem
+    * **name** (required) used to map the volume to an app's mountPoint at runtime. (string, restricted to the AC Name formatting)
     * **kind** (required) either "empty" or "host". "empty" fulfills a mount point by ensuring the path exists (writes go to container). "host" fulfills a mount point with a bind mount from a **source**.
     * **source** (required if **kind** is "host") absolute path on host to be bind mounted into the container under a mount point.
     * **readOnly** (optional if **kind** is "host") whether or not the volume should be mounted read only.

--- a/examples/container.json
+++ b/examples/container.json
@@ -9,6 +9,10 @@
         },
         {
             "app": "example.com/worker-backup",
+            "mounts": [
+                {"volume": "database", "mountPoint": "db"},
+                {"volume": "buildoutput", "mountPoint": "out"}
+            ],
             "imageID": "sha512-...",
             "isolators": [
                 {
@@ -30,18 +34,14 @@
     ],
     "volumes": [
         {
+            "name": "database",
             "kind": "host",
             "source": "/opt/tenant1/database",
-            "readOnly": true,
-            "fulfills": [
-                "database"
-            ]
+            "readOnly": true
         },
         {
-            "kind": "empty",
-            "fulfills": [
-                "buildoutput"
-            ]
+            "name": "buildoutput",
+            "kind": "empty"
         }
     ],
     "isolators": [

--- a/schema/container.go
+++ b/schema/container.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"encoding/json"
+	"errors"
 
 	"github.com/appc/spec/schema/types"
 )
@@ -68,10 +69,28 @@ func (al AppList) Get(name types.ACName) *RuntimeApp {
 	return nil
 }
 
+// RuntimeMountPoint describes the mapping between a volume and an apps
+// MountPoint that will be fulfilled at runtime.
+type Mount struct {
+	Volume     types.ACName `json:"volume"`
+	MountPoint types.ACName `json:"mountPoint"`
+}
+
+func (r Mount) assertValid() error {
+	if r.Volume.Empty() {
+		return errors.New("source must be set")
+	}
+	if r.MountPoint.Empty() {
+		return errors.New("destination must be set")
+	}
+	return nil
+}
+
 // RuntimeApp describes an application referenced in a ContainerRuntimeManifest
 type RuntimeApp struct {
 	Name        types.ACName      `json:"name"`
 	ImageID     types.Hash        `json:"imageID"`
+	Mounts      []Mount           `json:"mounts"`
 	Isolators   []types.Isolator  `json:"isolators"`
 	Annotations types.Annotations `json:"annotations"`
 }

--- a/schema/types/volume_test.go
+++ b/schema/types/volume_test.go
@@ -1,0 +1,73 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestVolumeFromString(t *testing.T) {
+	tests := []struct {
+		s string
+		v Volume
+	}{
+		{
+			"foobar,kind=host,source=/tmp",
+			Volume{
+				Name:     "foobar",
+				Kind:     "host",
+				Source:   "/tmp",
+				ReadOnly: false,
+			},
+		},
+		{
+			"foobar,kind=host,source=/tmp,readOnly=true",
+			Volume{
+				Name:     "foobar",
+				Kind:     "host",
+				Source:   "/tmp",
+				ReadOnly: true,
+			},
+		},
+		{
+			"foobar,kind=empty",
+			Volume{
+				Name: "foobar",
+				Kind: "empty",
+			},
+		},
+		{
+			"foobar,kind=empty,readOnly=true",
+			Volume{
+				Name:     "foobar",
+				Kind:     "empty",
+				ReadOnly: true,
+			},
+		},
+	}
+	for i, tt := range tests {
+		v, err := VolumeFromString(tt.s)
+		if err != nil {
+			t.Errorf("#%d: got err=%v, want nil", i, err)
+		}
+		if !reflect.DeepEqual(*v, tt.v) {
+			t.Errorf("#%d: v=%v, want %v", i, *v, tt.v)
+		}
+	}
+}
+
+func TestVolumeFromStringBad(t *testing.T) {
+	tests := []string{
+		"#foobar,kind=host,source=/tmp",
+		"foobar,kind=host,source=/tmp,readOnly=true,asdf=asdf",
+		"foobar,kind=empty,source=/tmp",
+	}
+	for i, in := range tests {
+		l, err := VolumeFromString(in)
+		if l != nil {
+			t.Errorf("#%d: got l=%v, want nil", i, l)
+		}
+		if err == nil {
+			t.Errorf("#%d: got err=nil, want non-nil", i)
+		}
+	}
+}


### PR DESCRIPTION
Add the concept of a mountPoint to the CRM and remove the idea that a volume
"fulfills" app mountPoints. The fulfills concept we troublesome because it was
putting the binding of a volume to a name at image/definition time instead of
runtime.

On the command line you could imagine it working something like this:

```
ace run
 example.com/webapp
 --volume ssl-share,type=empty
 example.com/ssl-key-downloader
 --mount ssl-share=example.com/ssl-key-downloader:ssl-out
 example.com/nginx-proxy
 --mount ssl-share=example.com/nginx-proxy:private-certs
```

This fixes #13