### PR TITLE
spec: remove private-network isolator

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -208,7 +208,6 @@ Additional isolators will be added to this specification over time.
 |block-io/write-bandwidth   |string|"&lt;path to file&gt; &lt;bytes&gt;"|"/tmp 1K"                           |
 |network-io/read-bandwidth  |string|"&lt;device name&gt; &lt;bytes&gt;" |"eth0 100M"                         |
 |network-io/write-bandwidth |string|"&lt;device name&gt; &lt;bytes&gt;" |"eth0 100M"                         |
-|private-network            |string|"&lt;true&#124;false&gt;"           |"true"                              |
 |capabilities/bounding-set  |string|"&lt;cap&gt; &lt;cap&gt; ..."       |"CAP_NET_BIND_SERVICE CAP_SYS_ADMIN"|
 
 #### Types
@@ -426,10 +425,6 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest)
             }
         ],
         "isolators": [
-            {
-                "name": "private-network",
-                "value": "true"
-            },
             {
                 "name": "cpu/shares",
                 "value": "20"

--- a/ace/image_manifest_main.json
+++ b/ace/image_manifest_main.json
@@ -50,10 +50,6 @@
         ],
         "isolators": [
             {
-                "name": "private-network",
-                "value": "true"
-            },
-            {
                 "name": "memory/limit",
                 "value": "1G"
             }

--- a/examples/image.json
+++ b/examples/image.json
@@ -44,10 +44,6 @@
         ],
         "isolators": [
             {
-                "name": "private-network",
-                "value": "true"
-            },
-            {
                 "name": "cpu/shares",
                 "value": "20"
             },


### PR DESCRIPTION
Having private-network as an optional isolator is problematic:
1. No private-network makes identity for metadata svc very difficult
2. The network is shared between all apps, reconciling conflicting
isolator values in manifests is impossible.