### PR TITLE
spec: sign/verify: use hmac-512 and separate content from sig

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -352,8 +352,8 @@ Accessible at `http://169.254.169.255/acMetadata/v1/container/hmac`
 
 | Entry | Description |
 |-------|-------------|
-|sign   | POST any object to this endpoint and retrieve a base64 hmac-sha256 signature as the response body. The metadata service holds onto the AES key as a sort of container TPM. |
-|verify | Verify a signature from another container. POST a form with signature=&lt;base64 encoded signature&gt; and uid=&lt;uid of the container that generated the signature&gt;. Returns 200 OK if the signature passes. |
+|sign   | POST a form with content=&lt;object to sign&gt; and retrieve a base64 hmac-sha512 signature as the response body. The metadata service holds onto the secret key as a sort of container TPM. |
+|verify | Verify a signature from another container. POST a form with content=&lt;object that was signed&gt;, uid=&lt;uid of the container that generated the signature&gt;, signature=&lt;base64 encoded signature&gt;. Returns 200 OK if the signature passes and 403 Forbidden if the signature check fails. |
 
 
 ## AC Name Type

--- a/ace/validator.go
+++ b/ace/validator.go
@@ -408,13 +408,16 @@ func validateSigning(metadataURL string, crm *schema.ContainerRuntimeManifest) r
 	plaintext := "Old MacDonald Had A Farm"
 
 	// Sign
-	sig, err := metadataPost(metadataURL, "/container/hmac/sign", []byte(plaintext))
+	sig, err := metadataPostForm(metadataURL, "/container/hmac/sign", url.Values{
+		"content": []string{plaintext},
+	})
 	if err != nil {
 		return append(r, err)
 	}
 
 	// Verify
 	_, err = metadataPostForm(metadataURL, "/container/hmac/verify", url.Values{
+		"content":   []string{plaintext},
 		"uid":       []string{crm.UUID.String()},
 		"signature": []string{string(sig)},
 	})


### PR DESCRIPTION
- Use HMAC-512 to be consistent with the rest of the spec.
- Have verify take in object that was signed so signature doesn't
have to store it (or its digest).