### PR TITLE
spec: introduce pods

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -582,7 +582,6 @@ JSON Schema for the Pod Manifest
         },
         {
             "app": "example.com/worker-backup",
-            "imageID": "sha512-...",
             "labels": [
                 {
                     "name": "os",
@@ -596,7 +595,6 @@ JSON Schema for the Pod Manifest
         },
         {
             "app": "example.com/reduce-worker-register",
-            "imageID": "sha512-...",
             "labels": [
                 {
                     "name": "version",


### PR DESCRIPTION
This is a first cut at pods, introducing a _Pod Manifest_ and tweaking some of
the other concepts slightly.

A Pod Manifest is simply a grouping of application images, and a convenient
deployable unit which can be provided as input to an executor.

However, the application image references in a pod manifest are not 
necessarily deterministic: they may use the Dependency Matching mechanism (as
in the `dependencies` section of Image Manifest) to resolve applications. For
example, a pod manifest with an application with a "version=latest" label
might resolve to a different particular application image at different points
in time.

In contrast, the application references in a Container Runtime Manifest MUST
be deterministic (i.e. be image IDs).