### PR TITLE
spec: exec: add parameter examples

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -399,7 +399,8 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest)
     ],
     "app": {
         "exec": [
-            "/usr/bin/reduce-worker"
+            "/usr/bin/reduce-worker",
+            "--quiet"
         ],
         "user": "100",
         "group": "300",
@@ -412,7 +413,8 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest)
             },
             {
                 "exec": [
-                    "/usr/bin/deregister-worker"
+                    "/usr/bin/deregister-worker",
+                    "--verbose"
                 ],
                 "name": "post-stop"
             }

--- a/examples/image.json
+++ b/examples/image.json
@@ -18,7 +18,8 @@
     ],
     "app": {
         "exec": [
-            "/usr/bin/reduce-worker"
+            "/usr/bin/reduce-worker",
+            "--quiet"
         ],
         "user": "100",
         "group": "300",
@@ -31,7 +32,8 @@
             },
             {
                 "exec": [
-                    "/usr/bin/deregister-worker"
+                    "/usr/bin/deregister-worker",
+                    "--verbose"
                 ],
                 "name": "post-stop"
             }


### PR DESCRIPTION
I thought that exec could contain several executables to run. But the
array is just here to contain parameters. Adding parameters in the
example will make it more obvious that "exec" can only contain *one*
executable with potential parameters.