### PR TITLE
SPEC: Redundant "http" scheme in metadata URLs

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -322,7 +322,7 @@ Clients querying any of these endpoints must specify the `Metadata-Flavor: AppCo
 
 Information about the container that this app is executing in.
 
-Retrievable at `http://$AC_METADATA_URL/acMetadata/v1/container`
+Retrievable at `$AC_METADATA_URL/acMetadata/v1/container`
 
 | Entry       | Description |
 |-------------|-------------|
@@ -335,7 +335,7 @@ Retrievable at `http://$AC_METADATA_URL/acMetadata/v1/container`
 Every running process will be able to introspect its App Name via the `AC_APP_NAME` environment variable.
 This is necessary to query for the correct endpoint metadata.
 
-Retrievable at `http://$AC_METADATA_URL/acMetadata/v1/apps/$AC_APP_NAME/`
+Retrievable at `$AC_METADATA_URL/acMetadata/v1/apps/$AC_APP_NAME/`
 
 | Entry         | Description |
 |---------------|-------------|
@@ -348,7 +348,7 @@ Retrievable at `http://$AC_METADATA_URL/acMetadata/v1/apps/$AC_APP_NAME/`
 As a basic building block for building a secure identity system, the metadata service must provide an HMAC (described in [RFC2104](https://www.ietf.org/rfc/rfc2104.txt)) endpoint for use by the apps in the container.
 This gives a cryptographically verifiable identity to the container based on its container unique ID and the container HMAC key, which is held securely by the ACE.
 
-Accessible at `http://169.254.169.255/acMetadata/v1/container/hmac`
+Accessible at `$AC_METADATA_URL/acMetadata/v1/container/hmac`
 
 | Entry | Description |
 |-------|-------------|


### PR DESCRIPTION
https://github.com/appc/spec/blob/master/SPEC.md#metadata-server list examples for URL endpoints like "Retrievable at http://$AC_METADATA_URL/acMetadata/v1/container". The default for "AC_METADATA_URL" is listed as "http://169.254.169.255" (already includes a scheme).

This is at least confusing, but probably just wrong.