### PR TITLE
tarheader: use minor and major macros

### DIFF
--- a/pkg/tarheader/pop_posix.go
+++ b/pkg/tarheader/pop_posix.go
@@ -17,6 +17,11 @@ func populateHeaderUnix(h *tar.Header, fi os.FileInfo, seen map[uint64]string) {
 	}
 	h.Uid = int(st.Uid)
 	h.Gid = int(st.Gid)
+	if st.Mode&syscall.S_IFMT == syscall.S_IFBLK || st.Mode&syscall.S_IFMT == syscall.S_IFCHR {
+		// FIXME: it would be better to use the C macros: major(3), minor(3)
+		h.Devminor = int64(st.Rdev & 0xff)
+		h.Devmajor = int64((st.Rdev >> 8) & 0xfff)
+	}
 	// If we have already seen this inode, generate a hardlink
 	p, ok := seen[uint64(st.Ino)]
 	if ok {

--- a/pkg/tarheader/pop_posix_test.go
+++ b/pkg/tarheader/pop_posix_test.go
@@ -1,0 +1,61 @@
+package tarheader
+
+import (
+	"archive/tar"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// mknod requires privilege ...
+func TestHeaderUnixDev(t *testing.T) {
+	hExpect := tar.Header{
+		Name:     "./dev/test0",
+		Size:     0,
+		Typeflag: tar.TypeBlock,
+		Devminor: 5,
+		Devmajor: 233,
+	}
+	// make our test block device
+	var path string
+	{
+		var err error
+		path, err = ioutil.TempDir("", "tarheader-test-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(path)
+		if err := os.Mkdir(filepath.Join(path, "dev"), os.FileMode(0755)); err != nil {
+			t.Fatal(err)
+		}
+		mode := uint32(hExpect.Mode&07777) | syscall.S_IFBLK
+		dev := uint32(((hExpect.Devminor & 0xfff00) << 12) | ((hExpect.Devmajor & 0xfff) << 8) | (hExpect.Devminor & 0xff))
+		if err := syscall.Mknod(filepath.Join(path, hExpect.Name), mode, int(dev)); err != nil {
+			if err == syscall.EPERM {
+				t.Skip("no permission to CAP_MKNOD")
+			}
+			t.Fatal(err)
+		}
+	}
+	fi, err := os.Stat(filepath.Join(path, hExpect.Name))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hGot := tar.Header{
+		Name:     "./dev/test0",
+		Size:     0,
+		Typeflag: tar.TypeBlock,
+	}
+
+	seen := map[uint64]string{}
+	populateHeaderUnix(&hGot, fi, seen)
+	if hGot.Devminor != hExpect.Devminor {
+		t.Errorf("dev minor: got %d, expected %d", hGot.Devminor, hExpect.Devminor)
+	}
+	if hGot.Devmajor != hExpect.Devmajor {
+		t.Errorf("dev major: got %d, expected %d", hGot.Devmajor, hExpect.Devmajor)
+	}
+}


### PR DESCRIPTION
on posix system's, include the minor and major device number, and use the sysmacros

/cc @jonboulle @alban 