### PR TITLE
discovery: fix walk for keys and add debugging

### DIFF
--- a/actool/discover.go
+++ b/actool/discover.go
@@ -33,13 +33,16 @@ func runDiscover(args []string) (exit int) {
 			stderr("%s: %s", name, err)
 			return 1
 		}
-		eps, err := discovery.DiscoverEndpoints(*app, transportFlags.Insecure)
+		eps, attempts, err := discovery.DiscoverEndpoints(*app, transportFlags.Insecure)
 		if err != nil {
 			stderr("error fetching %s: %s", name, err)
 			return 1
 		}
+		for _, a := range attempts {
+			fmt.Printf("discover walk: prefix: %s error: %v\n", a.Prefix, a.Error)
+		}
 		for _, aciEndpoint := range eps.ACIEndpoints {
-			fmt.Println("ACI: %s, Sig: %s\n", aciEndpoint.ACI, aciEndpoint.Sig)
+			fmt.Printf("ACI: %s, Sig: %s\n", aciEndpoint.ACI, aciEndpoint.Sig)
 		}
 		if len(eps.Keys) > 0 {
 			fmt.Println("Keys: " + strings.Join(eps.Keys, ","))

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -180,7 +180,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 
 	for i, tt := range tests {
 		httpGet = tt.get
-		de, err := DiscoverEndpoints(tt.app, true)
+		de, _, err := DiscoverEndpoints(tt.app, true)
 		if err != nil && !tt.expectDiscoverySuccess {
 			continue
 		}


### PR DESCRIPTION
Add two new functions to let a user control the Discover walking process and
then also add attempts list to keep track of errors that were encountered along
the way.

Fixes #166