### PR TITLE
spec: remove mention of metadata svc on 169.254.169.255

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -314,7 +314,6 @@ The app container specification defines an HTTP-based metadata service for provi
 ### Metadata Server
 
 The ACE must provide a Metadata server on the address given to the container via the `AC_METADATA_URL` environment variable.
-By convention, the default address will be `http://169.254.169.255`.
 
 Clients querying any of these endpoints must specify the `Metadata-Flavor: AppContainer` header.
 


### PR DESCRIPTION
Since the metadata service address is specified in
AC_METADATA_URL env var, there's little value in
setting expectation that the service will be on a
particular IP. From the impl point of view, it may
be much easier to not have it listen on a particular
link-local address.