### PR TITLE
SPEC: move to .aci.asc file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ user: "Joe Bloggs (Example, Inc) <joe@example.com>"
 Wrote main layout to      bin/ace_main_layout
 Wrote unsigned main ACI   bin/ace_validator_main.aci
 Wrote main layout hash    bin/sha512-f7eb89d44f44d416f2872e43bc5a4c6c3e12c460e845753e0a7b28cdce0e89d2
-Wrote main ACI signature  bin/ace_validator_main.sig
+Wrote main ACI signature  bin/ace_validator_main.aci.asc
 
 You need a passphrase to unlock the secret key for
 user: "Joe Bloggs (Example, Inc) <joe@example.com>"
@@ -203,7 +203,7 @@ user: "Joe Bloggs (Example, Inc) <joe@example.com>"
 Wrote sidekick layout to      bin/ace_sidekick_layout
 Wrote unsigned sidekick ACI   bin/ace_validator_sidekick.aci
 Wrote sidekick layout hash    bin/sha512-13b5598069dbf245391cc12a71e0dbe8f8cdba672072135ebc97948baacf30b2
-Wrote sidekick ACI signature  bin/ace_validator_sidekick.sig
+Wrote sidekick ACI signature  bin/ace_validator_sidekick.aci.asc
 
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -70,7 +70,7 @@ This set of formats makes it easy to build, host and secure a container using te
 - Image archives MUST be a tar formatted file.
 - All files in the image MUST maintain all of their original properties, including timestamps, Unix modes, and extended attributes (xattrs).
 - Image archives MUST be named with the suffix `.aci`, irrespective of compression/encryption (see below).
-- Image archives SHOULD be signed using PGP, in detached signature mode.
+- Image archives SHOULD be signed using PGP, the format MUST be ascii-armored detached signature mode.
 - Image signatures MUST be named with the suffix `.aci.asc`.
 
 There are two further transformations that may be applied to image archives for transport:
@@ -82,7 +82,7 @@ In this case, the ACI is both compressed and encrypted.
 
 ```
 tar cvf reduce-worker.tar manifest rootfs
-gpg --output reduce-worker.sig --detach-sig reduce-worker.tar
+gpg --armor --output reduce-worker.aci.asc --detach-sig reduce-worker.tar
 gzip reduce-worker.tar -c > reduce-worker.aci
 gpg --output reduce-worker.aci --digest-algo sha256 --cipher-algo AES256 --symmetric reduce-worker.aci
 ```
@@ -240,9 +240,9 @@ For example, given the app name `example.com/reduce-worker`, with version `1.0.0
     https://example.com/reduce-worker-1.0.0-linux-amd64.aci
 
 If this fails, move on to meta discovery.
-If this succeeds, try fetching the signature using the same template but with a `.sig` extension:
+If this succeeds, try fetching the signature using the same template but with a `.aci.asc` extension:
 
-    https://example.com/reduce-worker-1.0.0-linux-amd64.sig
+    https://example.com/reduce-worker-1.0.0-linux-amd64.aci.asc
 
 ### Meta Discovery
 
@@ -275,12 +275,12 @@ The algorithm first ensures that the prefix of the AC Name matches the prefix-ma
 curl $(echo "$urltmpl" | sed -e "s/{name}/$appname/" -e "s/{version}/$version/" -e "s/{os}/$os/" -e "s/{arch}/$arch/" -e "s/{ext}/$ext/")
 ```
 
-where _appname_, _version_, _os_, and _arch_ are set to their respective values for the application, and _ext_ is either `aci` or `sig` for retrieving an app container image or signature respectively.
+where _appname_, _version_, _os_, and _arch_ are set to their respective values for the application, and _ext_ is either `aci` or `aci.asc` for retrieving an app container image or signature respectively.
 
 In our example above this would be:
 
 ```
-sig: https://storage.example.com/linux/amd64/reduce-worker-1.0.0.sig
+sig: https://storage.example.com/linux/amd64/reduce-worker-1.0.0.aci.asc
 aci: https://storage.example.com/linux/amd64/reduce-worker-1.0.0.aci
 keys: https://example.com/pubkeys.gpg
 ```

--- a/ace/build_aci
+++ b/ace/build_aci
@@ -29,12 +29,12 @@ for typ in main sidekick; do
 		../actool build --overwrite ./ ../ace-validator-${typ}.aci
 		# TODO(jonboulle): create uncompressed instead, then gzip?
 		HASH=sha512-$(gzip -d -f ../ace-validator-${typ}.aci -c | sha512sum - | awk '{print $1}')
-		gpg --cipher-algo AES256 --output ace-validator-${typ}.sig --detach-sig ../ace-validator-${typ}.aci
-		mv ace-validator-${typ}.sig ../
+		gpg --cipher-algo AES256 --output ace-validator-${typ}.aci.asc --detach-sig ../ace-validator-${typ}.aci
+		mv ace-validator-${typ}.aci.asc ../
 	popd >/dev/null
 	echo "Wrote ${typ} layout to      ${layoutdir}"
 	echo "Wrote unsigned ${typ} ACI   bin/ace-validator-${typ}.aci"
 	ln -s ${PWD}/bin/ace-validator-${typ}.aci bin/${HASH}
 	echo "Wrote ${typ} layout hash    bin/${HASH}"
-	echo "Wrote ${typ} ACI signature  bin/ace-validator-${typ}.sig"
+	echo "Wrote ${typ} ACI signature  bin/ace-validator-${typ}.aci.asc"
 done

--- a/actool/discover.go
+++ b/actool/discover.go
@@ -42,7 +42,7 @@ func runDiscover(args []string) (exit int) {
 			fmt.Printf("discover walk: prefix: %s error: %v\n", a.Prefix, a.Error)
 		}
 		for _, aciEndpoint := range eps.ACIEndpoints {
-			fmt.Printf("ACI: %s, Sig: %s\n", aciEndpoint.ACI, aciEndpoint.Sig)
+			fmt.Printf("ACI: %s, ASC: %s\n", aciEndpoint.ACI, aciEndpoint.ASC)
 		}
 		if len(eps.Keys) > 0 {
 			fmt.Println("Keys: " + strings.Join(eps.Keys, ","))

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -19,7 +19,7 @@ type acMeta struct {
 
 type ACIEndpoint struct {
 	ACI string
-	Sig string
+	ASC string
 }
 
 type Endpoints struct {
@@ -135,7 +135,7 @@ func doDiscover(pre string, app App, insecure bool) (*Endpoints, error) {
 		case "ac-discovery":
 			// Ignore not handled variables as {ext} isn't already rendered.
 			uri, _ := renderTemplate(m.uri, tplVars...)
-			sig, ok := renderTemplate(uri, "{ext}", "sig")
+			asc, ok := renderTemplate(uri, "{ext}", "aci.asc")
 			if !ok {
 				continue
 			}
@@ -143,7 +143,7 @@ func doDiscover(pre string, app App, insecure bool) (*Endpoints, error) {
 			if !ok {
 				continue
 			}
-			de.ACIEndpoints = append(de.ACIEndpoints, ACIEndpoint{ACI: aci, Sig: sig})
+			de.ACIEndpoints = append(de.ACIEndpoints, ACIEndpoint{ACI: aci, ASC: asc})
 
 		case "ac-discovery-pubkeys":
 			de.Keys = append(de.Keys, m.uri)

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -74,11 +74,11 @@ func TestDiscoverEndpoints(t *testing.T) {
 			[]ACIEndpoint{
 				ACIEndpoint{
 					ACI: "https://storage.example.com/example.com/myapp-1.0.0.aci?torrent",
-					Sig: "https://storage.example.com/example.com/myapp-1.0.0.sig?torrent",
+					ASC: "https://storage.example.com/example.com/myapp-1.0.0.aci.asc?torrent",
 				},
 				ACIEndpoint{
 					ACI: "hdfs://storage.example.com/example.com/myapp-1.0.0.aci",
-					Sig: "hdfs://storage.example.com/example.com/myapp-1.0.0.sig",
+					ASC: "hdfs://storage.example.com/example.com/myapp-1.0.0.aci.asc",
 				},
 			},
 			[]string{"https://example.com/pubkeys.gpg"},
@@ -97,11 +97,11 @@ func TestDiscoverEndpoints(t *testing.T) {
 			[]ACIEndpoint{
 				ACIEndpoint{
 					ACI: "https://storage.example.com/example.com/myapp/foobar-1.0.0.aci?torrent",
-					Sig: "https://storage.example.com/example.com/myapp/foobar-1.0.0.sig?torrent",
+					ASC: "https://storage.example.com/example.com/myapp/foobar-1.0.0.aci.asc?torrent",
 				},
 				ACIEndpoint{
 					ACI: "hdfs://storage.example.com/example.com/myapp/foobar-1.0.0.aci",
-					Sig: "hdfs://storage.example.com/example.com/myapp/foobar-1.0.0.sig",
+					ASC: "hdfs://storage.example.com/example.com/myapp/foobar-1.0.0.aci.asc",
 				},
 			},
 			[]string{"https://example.com/pubkeys.gpg"},
@@ -135,7 +135,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			[]ACIEndpoint{
 				ACIEndpoint{
 					ACI: "https://storage.example.com/example.com/myapp-1.0.0.aci",
-					Sig: "https://storage.example.com/example.com/myapp-1.0.0.sig",
+					ASC: "https://storage.example.com/example.com/myapp-1.0.0.aci.asc",
 				},
 			},
 			[]string{"https://example.com/pubkeys.gpg"},
@@ -152,7 +152,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			[]ACIEndpoint{
 				ACIEndpoint{
 					ACI: "https://storage.example.com/example.com/myapp-latest.aci",
-					Sig: "https://storage.example.com/example.com/myapp-latest.sig",
+					ASC: "https://storage.example.com/example.com/myapp-latest.aci.asc",
 				},
 			},
 			[]string{"https://example.com/pubkeys.gpg"},
@@ -171,7 +171,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			[]ACIEndpoint{
 				ACIEndpoint{
 					ACI: "https://storage.example.com/example.com/myapp-1.0.0.aci",
-					Sig: "https://storage.example.com/example.com/myapp-1.0.0.sig",
+					ASC: "https://storage.example.com/example.com/myapp-1.0.0.aci.asc",
 				},
 			},
 			[]string{"https://example.com/pubkeys.gpg"},


### PR DESCRIPTION
Use the .aci.asc file extension since we are expecting an ASCII armored
extension of the aci file.

Discussed on: https://github.com/appc/spec/pull/156