### PR TITLE
schema: Clarify legal edge characters in AC Name Type

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -365,7 +365,9 @@ Accessible at `$AC_METADATA_URL/acMetadata/v1/container/hmac`
 
 ## AC Name Type
 
-An AC Name Type is restricted to lowercase characters accepted by the DNS [RFC](http://tools.ietf.org/html/rfc1123#page-13) and "/".
+An AC Name Type is restricted to lowercase characters accepted by the DNS [RFC1123](http://tools.ietf.org/html/rfc1123#page-13) and "/".
+An AC Name Type cannot be an empty string and must begin and end with an alphanumeric character.
+An AC Name Type will match the following [RE2](https://code.google.com/p/re2/wiki/Syntax) regular expression: `^[a-z0-9]+([-./][a-z0-9]+)*$`
 
 Examples:
 
@@ -374,7 +376,6 @@ Examples:
 * example.com/ourapp
 * sub-domain.example.com/org/product/release
 
-An AC Name Type cannot be an empty string.
 The AC Name Type is used as the primary key for a number of fields in the schemas below.
 The schema validator will ensure that the keys conform to these constraints.
 

--- a/schema/types/acname.go
+++ b/schema/types/acname.go
@@ -3,16 +3,12 @@ package types
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"regexp"
 	"strings"
 )
 
-const (
-	valchars = `abcdefghijklmnopqrstuvwxyz0123456789.-/`
-)
-
 var (
+	validACName  = regexp.MustCompile("^[a-z0-9]+([-./][a-z0-9]+)*$")
 	invalidChars = regexp.MustCompile("[^a-z0-9./-]")
 	invalidEdges = regexp.MustCompile("(^[./-]+)|([./-]+$)")
 )
@@ -49,14 +45,9 @@ func (n ACName) Empty() bool {
 // NewACName generates a new ACName from a string. If the given string is
 // not a valid ACName, nil and an error are returned.
 func NewACName(s string) (*ACName, error) {
-	if len(s) == 0 {
-		return nil, fmt.Errorf("ACName cannot be empty")
-	}
-	for _, c := range s {
-		if !strings.ContainsRune(valchars, c) {
-			msg := fmt.Sprintf("invalid char in ACName: %c", c)
-			return nil, ACNameError(msg)
-		}
+	if !validACName.MatchString(s) {
+		return nil, ACNameError("Invalid ACName, must contain lower case " +
+			"alphanumeric characters plus \".\", \"-\", \"/\"")
 	}
 	return (*ACName)(&s), nil
 }

--- a/schema/types/acname_test.go
+++ b/schema/types/acname_test.go
@@ -29,6 +29,12 @@ func TestNewACNameBad(t *testing.T) {
 		"EXAMPLE.com",
 		"foo.com/BAR",
 		"example.com/app_1",
+		"/app",
+		"app/",
+		"-app",
+		"app-",
+		".app",
+		"app.",
 	}
 	for i, in := range tests {
 		l, err := NewACName(in)


### PR DESCRIPTION
- Include constraint from RFC1123/RFC952 that the name
  must begin and end with an alphanumeric character.
  (not a hyphen, period, or slash)

(Opened as a point of discussion. If this seems appropriate, I can add to tests, etc)