### PR TITLE
Pass TERM variable to application's environment if appropriate

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -195,6 +195,7 @@ Note that logging mechanisms other than stdout and stderr are not required by th
 * **USER, LOGNAME** username of the user executing this app
 * **HOME** home directory of the user
 * **SHELL** login shell of the user
+* **TERM** terminal type if app is started on a tty/pty device; if application inherits stdio from host and it is a terminal, `$TERM` is copied from host environment.
 * **AC_APP_NAME** name of the application, as defined in the image manifest
 * **AC_METADATA_URL** URL where the metadata service for this container can be found
 


### PR DESCRIPTION
Currently, `$TERM` is always unset, which is problematic when one attempts to work interactively within a container. Since runtime is responsible for providing stdin/stdout/stderr to the app, it should also set `$TERM` if application runs on a terminal device.