### PR TITLE
Support ports in the ACName

### DIFF
--- a/discovery/parse.go
+++ b/discovery/parse.go
@@ -32,13 +32,20 @@ func NewApp(name string, labels map[string]string) (*App, error) {
 // Example app parameters:
 // 	example.com/reduce-worker:1.0.0
 // 	example.com/reduce-worker,channel=alpha,label=value
+// 	example.com:8080/reduce-worker:1.0.0
+// 	example.com:8080/reduce-worker
 func NewAppFromString(app string) (*App, error) {
 	var (
 		name   string
 		labels map[string]string
 	)
 
-	app = strings.Replace(app, ":", ",version=", -1)
+	i := strings.Index(app, "/")
+	if i == -1 {
+		app = strings.Replace(app, ":", ",version=", -1)
+	} else {
+		app = app[:i] + strings.Replace(app[i:], ":", ",version=", -1)
+	}
 	app = "name=" + app
 	v, err := url.ParseQuery(strings.Replace(app, ",", "&", -1))
 	if err != nil {

--- a/discovery/parse_test.go
+++ b/discovery/parse_test.go
@@ -36,6 +36,26 @@ func TestNewAppFromString(t *testing.T) {
 
 			false,
 		},
+		{
+			"example.com:8080/reduce-worker:1.0.0",
+
+			&App{
+				Name: "example.com:8080/reduce-worker",
+				Labels: map[string]string{
+					"version": "1.0.0",
+				},
+			},
+			false,
+		},
+		{
+			"example.com:8080/reduce-worker",
+
+			&App{
+				Name:   "example.com:8080/reduce-worker",
+				Labels: map[string]string{},
+			},
+			false,
+		},
 
 		// bad AC name for app
 		{

--- a/schema/types/acname.go
+++ b/schema/types/acname.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	valchars = `abcdefghijklmnopqrstuvwxyz0123456789.-/`
+	valchars = `abcdefghijklmnopqrstuvwxyz0123456789.-/:`
 )
 
 // ACName (an App-Container Name) is a format used by keys in different


### PR DESCRIPTION
This is a subtlety of the ACName, which might require some discussion.

I realize the port is not part of the DNS RFC, but for the purposes of the name of an image, it is more like an URL. In this way it can still be accessed the same way and use the same ac-discovery, But would need to support having the port number present.

This adds a couple of additional parse tests and modifications to support port on the image name.