### PR TITLE
actool: default os and arch to GOOS and GOARCH

### DIFF
--- a/actool/discover.go
+++ b/actool/discover.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/appc/spec/discovery"
@@ -29,6 +30,12 @@ func runDiscover(args []string) (exit int) {
 
 	for _, name := range args {
 		app, err := discovery.NewAppFromString(name)
+		if app.Labels["os"] == "" {
+			app.Labels["os"] = runtime.GOOS
+		}
+		if app.Labels["arch"] == "" {
+			app.Labels["arch"] = runtime.GOARCH
+		}
 		if err != nil {
 			stderr("%s: %s", name, err)
 			return 1


### PR DESCRIPTION
If the user isn't explicit add these labels as helpers.

This fixes for example:

```
./bin/actool discover quay.io/philips/golang-isoutyet
discover walk: prefix: quay.io/philips/golang-isoutyet error: expected a 200 OK got 404
discover walk: prefix: quay.io/philips error: expected a 200 OK got 404
ACI: https://quay.io/c1/aci/quay.io/philips/golang-isoutyet/latest/aci/darwin/amd64/, Sig: https://quay.io/c1/aci/quay.io/philips/golang-isoutyet/latest/sig/darwin/amd64/
Keys: https://quay.io/aci-signing-key
```