### PR TITLE
aci: fix ManifestFromImage to handle ./manifest

### DIFF
--- a/aci/file.go
+++ b/aci/file.go
@@ -7,11 +7,13 @@ import (
 	"compress/gzip"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/appc/spec/schema"
 )
@@ -111,7 +113,6 @@ func XzReader(r io.Reader) io.ReadCloser {
 // ManifestFromImage extracts a new schema.ImageManifest from the given ACI image.
 func ManifestFromImage(rs io.ReadSeeker) (*schema.ImageManifest, error) {
 	var im schema.ImageManifest
-	manifestFound := false
 
 	tr, err := NewCompressedTarReader(rs)
 	if err != nil {
@@ -120,26 +121,24 @@ func ManifestFromImage(rs io.ReadSeeker) (*schema.ImageManifest, error) {
 
 	for {
 		hdr, err := tr.Next()
-		if err != nil {
-			return nil, err
-		}
-		if hdr.Name == "manifest" {
-			data, err := ioutil.ReadAll(tr)
-			if err != nil {
-				return nil, err
+		switch err {
+		case io.EOF:
+			return nil, errors.New("missing manifest")
+		case nil:
+			if filepath.Clean(hdr.Name) == "manifest" {
+				data, err := ioutil.ReadAll(tr)
+				if err != nil {
+					return nil, err
+				}
+				if err := im.UnmarshalJSON(data); err != nil {
+					return nil, err
+				}
+				return &im, nil
 			}
-			if err := im.UnmarshalJSON(data); err != nil {
-				return nil, err
-			}
-			manifestFound = true
-			break
+		default:
+			return nil, fmt.Errorf("error extracting tarball: %v", err)
 		}
 	}
-
-	if !manifestFound {
-		return nil, errors.New("error: missing manifest")
-	}
-	return &im, nil
 }
 
 // NewCompressedTarReader creates a new tar.Reader reading from the given ACI image.

--- a/aci/file_test.go
+++ b/aci/file_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func newTestACI() (*os.File, error) {
+func newTestACI(usedotslash bool) (*os.File, error) {
 	tf, err := ioutil.TempFile("", "")
 	if err != nil {
 		return nil, err
@@ -19,8 +19,12 @@ func newTestACI() (*os.File, error) {
 	gw := gzip.NewWriter(tf)
 	tw := tar.NewWriter(gw)
 
+	manifestPath := "manifest"
+	if usedotslash {
+		manifestPath = "./" + manifestPath
+	}
 	hdr := &tar.Header{
-		Name: "manifest",
+		Name: manifestPath,
 		Size: int64(len(manifestBody)),
 	}
 	if err := tw.WriteHeader(hdr); err != nil {
@@ -55,50 +59,52 @@ func newEmptyTestACI() (*os.File, error) {
 }
 
 func TestManifestFromImage(t *testing.T) {
-	img, err := newTestACI()
-	if err != nil {
-		t.Fatalf("newTestACI: unexpected error %v", err)
-	}
-	defer img.Close()
-	defer os.Remove(img.Name())
+	for _, usedotslash := range []bool{false, true} {
+		img, err := newTestACI(usedotslash)
+		if err != nil {
+			t.Fatalf("newTestACI: unexpected error: %v", err)
+		}
+		defer img.Close()
+		defer os.Remove(img.Name())
 
-	im, err := ManifestFromImage(img)
-	if err != nil {
-		t.Fatalf("ManifestFromImage: unexpected error %v", err)
-	}
-	if im.Name.String() != "example.com/app" {
-		t.Errorf("expected %s, got %s", "example.com/app", im.Name.String())
-	}
+		im, err := ManifestFromImage(img)
+		if err != nil {
+			t.Fatalf("ManifestFromImage: unexpected error: %v", err)
+		}
+		if im.Name.String() != "example.com/app" {
+			t.Errorf("expected %s, got %s", "example.com/app", im.Name.String())
+		}
 
-	emptyImg, err := newEmptyTestACI()
-	if err != nil {
-		t.Fatalf("newEmptyTestACI: unexpected error %v", err)
-	}
-	defer emptyImg.Close()
-	defer os.Remove(emptyImg.Name())
+		emptyImg, err := newEmptyTestACI()
+		if err != nil {
+			t.Fatalf("newEmptyTestACI: unexpected error: %v", err)
+		}
+		defer emptyImg.Close()
+		defer os.Remove(emptyImg.Name())
 
-	im, err = ManifestFromImage(emptyImg)
-	if err == nil {
-		t.Fatalf("ManifestFromImage: expected error")
+		im, err = ManifestFromImage(emptyImg)
+		if err == nil {
+			t.Fatalf("ManifestFromImage: expected error")
+		}
 	}
 }
 
 func TestNewCompressedTarReader(t *testing.T) {
-	img, err := newTestACI()
+	img, err := newTestACI(false)
 	if err != nil {
-		t.Fatalf("newTestACI: unexpected error %v", err)
+		t.Fatalf("newTestACI: unexpected error: %v", err)
 	}
 	defer img.Close()
 	defer os.Remove(img.Name())
 
 	cr, err := NewCompressedTarReader(img)
 	if err != nil {
-		t.Fatalf("NewCompressedTarReader: unexpected error %v", err)
+		t.Fatalf("NewCompressedTarReader: unexpected error: %v", err)
 	}
 
 	ftype, err := DetectFileType(cr)
 	if err != nil {
-		t.Fatalf("DetectFileType: unexpected error %v", err)
+		t.Fatalf("DetectFileType: unexpected error: %v", err)
 	}
 
 	if ftype != TypeText {
@@ -107,21 +113,21 @@ func TestNewCompressedTarReader(t *testing.T) {
 }
 
 func TestNewCompressedReader(t *testing.T) {
-	img, err := newTestACI()
+	img, err := newTestACI(false)
 	if err != nil {
-		t.Fatalf("newTestACI: unexpected error %v", err)
+		t.Fatalf("newTestACI: unexpected error: %v", err)
 	}
 	defer img.Close()
 	defer os.Remove(img.Name())
 
 	cr, err := NewCompressedReader(img)
 	if err != nil {
-		t.Fatalf("NewCompressedReader: unexpected error %v", err)
+		t.Fatalf("NewCompressedReader: unexpected error: %v", err)
 	}
 
 	ftype, err := DetectFileType(cr)
 	if err != nil {
-		t.Fatalf("DetectFileType: unexpected error %v", err)
+		t.Fatalf("DetectFileType: unexpected error: %v", err)
 	}
 
 	if ftype != TypeTar {


### PR DESCRIPTION
The tar Header.Name (for example with gnu tar) can start with ./ (for example
./manifest). In this case ManifestFromImage will fail.

Plus, I noticed that the error was strange: unexpected error EOF. This is due
to the io.EOF error not being handled. So I rewrote the code to handle it (now
it's similar to github.com/coreos/rocket/pkg/tar.ExtractTar).