### PR TITLE
tarheader: pop_posix: define also _DEFAULT_SOURCE

### DIFF
--- a/pkg/tarheader/pop_posix.go
+++ b/pkg/tarheader/pop_posix.go
@@ -2,6 +2,7 @@ package tarheader
 
 /*
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #include <sys/types.h>
 
 unsigned int


### PR DESCRIPTION
On my fedora 21 system I have this warning:
/usr/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]

feature_test_macros(7) says that, starting from glibc 2.20, _BSD_SOURCE is
deprecated and to use _DEFAULT_SOURCE instead.
It also suggests (to compile without warnings code that needs _BSD_SOURCE for
glibc <= 2.19) to define both _BSD_SOURCE and _DEFAULT_SOURCE.