### PR TITLE
acirenderer: add dependencies resolving

### DIFF
--- a/pkg/acirenderer/acirenderer.go
+++ b/pkg/acirenderer/acirenderer.go
@@ -61,6 +61,28 @@ type ACIFiles struct {
 // RenderedACI is an (ordered) slice of ACIFiles
 type RenderedACI []*ACIFiles
 
+// GetRenderedACIWithImageID, given an imageID, starts with the matching image
+// available in the store, creates the dependencies list and returns the
+// RenderedACI list.
+func GetRenderedACIWithImageID(imageID types.Hash, ap ACIRegistry) (RenderedACI, error) {
+	imgs, err := CreateDepListFromImageID(imageID, ap)
+	if err != nil {
+		return nil, err
+	}
+	return GetRenderedACIFromList(imgs, ap)
+}
+
+// GetRenderedACI, given an image app name and optional labels, starts with the
+// best matching image available in the store, creates the dependencies list
+// and returns the RenderedACI list.
+func GetRenderedACI(name types.ACName, labels types.Labels, ap ACIRegistry) (RenderedACI, error) {
+	imgs, err := CreateDepListFromNameLabels(name, labels, ap)
+	if err != nil {
+		return nil, err
+	}
+	return GetRenderedACIFromList(imgs, ap)
+}
+
 // GetRenderedACIFromList returns the RenderedACI list. All file outside rootfs
 // are excluded (at the moment only "manifest").
 func GetRenderedACIFromList(imgs Images, ap ACIProvider) (RenderedACI, error) {

--- a/pkg/acirenderer/acirenderer.go
+++ b/pkg/acirenderer/acirenderer.go
@@ -1,0 +1,202 @@
+package acirenderer
+
+import (
+	"archive/tar"
+	"crypto/sha512"
+	"fmt"
+	"hash"
+	"io"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
+)
+
+// An ACIRegistry provides all functions of an ACIProvider plus functions to
+// search for an aci and get its contents
+type ACIRegistry interface {
+	ACIProvider
+	GetImageManifest(key string) (*schema.ImageManifest, error)
+	GetACI(name types.ACName, labels types.Labels) (string, error)
+}
+
+// An ACIProvider provides functions to get an ACI contents, to convert an
+// ACI hash to the key under which the ACI is known to the provider and to resolve an
+// ImageID to the key under which it's known to the provider.
+type ACIProvider interface {
+	// Read the ACI contents stream given the key. Use ResolveKey to
+	// convert an ImageID to the relative provider's key.
+	ReadStream(key string) (io.ReadCloser, error)
+	// Converts an ImageID to the, if existent, key under which the
+	// ACI is known to the provider
+	ResolveKey(key string) (string, error)
+	// Converts a Hash to the provider's key
+	HashToKey(h hash.Hash) string
+}
+
+// An Image contains the ImageManifest, the ACIProvider's key and its Level in
+// the dependency tree.
+type Image struct {
+	Im    *schema.ImageManifest
+	Key   string
+	Level uint16
+}
+
+// Images encapsulates an ordered slice of Image structs. It represents a flat
+// dependency tree.
+// The upper Image should be the first in the slice with a level of 0.
+// For example if A is the upper image and has two deps (in order B and C). And C has one dep (D),
+// the slice (reporting the app name and excluding im and Hash) should be:
+// [{A, Level: 0}, {C, Level:1}, {D, Level: 2}, {B, Level: 1}]
+type Images []Image
+
+// ACIFiles represents which files to extract for every ACI
+type ACIFiles struct {
+	Key     string
+	FileMap map[string]struct{}
+}
+
+// RenderedACI is an (ordered) slice of ACIFiles
+type RenderedACI []*ACIFiles
+
+// GetRenderedACIFromList returns the RenderedACI list. All file outside rootfs
+// are excluded (at the moment only "manifest").
+func GetRenderedACIFromList(imgs Images, ap ACIProvider) (RenderedACI, error) {
+	if len(imgs) == 0 {
+		return nil, fmt.Errorf("image list empty")
+	}
+
+	allFiles := make(map[string]struct{})
+	renderedACI := RenderedACI{}
+
+	first := true
+	for i, img := range imgs {
+		pwlm := getUpperPWLM(imgs, i)
+		ra, err := getACIFiles(img, ap, allFiles, pwlm)
+		if err != nil {
+			return nil, err
+		}
+		// Use the manifest from the upper ACI
+		if first {
+			ra.FileMap["manifest"] = struct{}{}
+			first = false
+		}
+		renderedACI = append(renderedACI, ra)
+	}
+
+	return renderedACI, nil
+}
+
+// getUpperPWLM returns the pwl at the lower level for the branch where
+// img[pos] lives.
+func getUpperPWLM(imgs Images, pos int) map[string]struct{} {
+	var pwlm map[string]struct{}
+	curlevel := imgs[pos].Level
+	// Start from our position and go back ignoring the other leafs.
+	for i := pos; i >= 0; i-- {
+		img := imgs[i]
+		if img.Level < curlevel && len(img.Im.PathWhitelist) > 0 {
+			pwlm = pwlToMap(img.Im.PathWhitelist)
+		}
+		curlevel = img.Level
+	}
+	return pwlm
+}
+
+// getACIFiles returns the ACIFiles struct for the given image. All files
+// outside rootfs are excluded (at the moment only "manifest").
+func getACIFiles(img Image, ap ACIProvider, allFiles map[string]struct{}, pwlm map[string]struct{}) (*ACIFiles, error) {
+	rs, err := ap.ReadStream(img.Key)
+	if err != nil {
+		return nil, err
+	}
+	defer rs.Close()
+
+	hash := sha512.New()
+	r := io.TeeReader(rs, hash)
+
+	ra := &ACIFiles{FileMap: make(map[string]struct{})}
+	if err = Walk(tar.NewReader(r), func(hdr *tar.Header) error {
+		name := hdr.Name
+		cleanName := filepath.Clean(name)
+
+		// Ignore files outside /rootfs/ (at the moment only "manifest")
+		if !strings.HasPrefix(cleanName, "rootfs/") {
+			return nil
+		}
+
+		// Is the file in our PathWhiteList?
+		// If the file is a directory continue also if not in PathWhiteList
+		if hdr.Typeflag != tar.TypeDir {
+			if len(img.Im.PathWhitelist) > 0 {
+				thispwlm := pwlToMap(img.Im.PathWhitelist)
+				if _, ok := thispwlm[cleanName]; !ok {
+					return nil
+				}
+			}
+		}
+		// Is the file in the lower level PathWhiteList of this img branch?
+		if pwlm != nil {
+			if _, ok := pwlm[cleanName]; !ok {
+				return nil
+			}
+		}
+		// Is the file already provided by a previous image?
+		if _, ok := allFiles[cleanName]; ok {
+			return nil
+		}
+		ra.FileMap[cleanName] = struct{}{}
+		allFiles[cleanName] = struct{}{}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// Tar does not necessarily read the complete file, so ensure we read the entirety into the hash
+	if _, err := io.Copy(ioutil.Discard, r); err != nil {
+		return nil, fmt.Errorf("error reading ACI: %v", err)
+	}
+
+	if g := ap.HashToKey(hash); g != img.Key {
+		return nil, fmt.Errorf("image hash does not match expected (%s != %s)", g, img.Key)
+	}
+
+	ra.Key = img.Key
+	return ra, nil
+}
+
+// pwlToMap converts a pathWhiteList slice to a map for faster search
+// It will also prepend "rootfs/" to the provided paths and they will be
+// relative to "/" so they can be easily compared with the tar.Header.Name
+// If pwl length is 0, a nil map is returned
+func pwlToMap(pwl []string) map[string]struct{} {
+	if len(pwl) == 0 {
+		return nil
+	}
+	m := make(map[string]struct{}, len(pwl))
+	for _, name := range pwl {
+		cleanName := filepath.Clean(name)
+		relpath := filepath.Join("rootfs/", cleanName)
+		m[relpath] = struct{}{}
+	}
+	return m
+}
+
+func Walk(tarReader *tar.Reader, walkFunc func(hdr *tar.Header) error) error {
+	for {
+		hdr, err := tarReader.Next()
+		if err == io.EOF {
+			// end of tar archive
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("Error reading tar entry: %v", err)
+		}
+		if err := walkFunc(hdr); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/acirenderer/acirenderer_test.go
+++ b/pkg/acirenderer/acirenderer_test.go
@@ -298,6 +298,10 @@ func TestDirFromParent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	err = checkRenderACI("example.com/test02", expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 // Test an image with 1 dep. The image provides a dir not provided by the parent.
@@ -386,6 +390,10 @@ func TestNewDir(t *testing.T) {
 
 	images := Images{image2, image1}
 	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = checkRenderACI("example.com/test02", expectedFiles, ds)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -487,6 +495,10 @@ func TestDirOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	err = checkRenderACI("example.com/test02", expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 // Test an image with 1 dep. The parent provides a file not provided by the image.
@@ -578,6 +590,10 @@ func TestFileFromParent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	err = checkRenderACI("example.com/test02", expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 // Test an image with 1 dep. The image provides a file not provided by the parent.
@@ -666,6 +682,10 @@ func TestNewFile(t *testing.T) {
 
 	images := Images{image2, image1}
 	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = checkRenderACI("example.com/test02", expectedFiles, ds)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -764,6 +784,10 @@ func TestFileOverride(t *testing.T) {
 
 	images := Images{image2, image1}
 	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = checkRenderACI("example.com/test02", expectedFiles, ds)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -944,6 +968,10 @@ func TestPWLOnlyParent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	err = checkRenderACI("example.com/test02", expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 // Test an image with 1 dep. The upper image has a pathWhiteList.
@@ -1116,6 +1144,10 @@ func TestPWLOnlyImage(t *testing.T) {
 
 	images := Images{image2, image1}
 	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = checkRenderACI("example.com/test02", expectedFiles, ds)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1328,6 +1360,10 @@ func Test2Deps1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	err = checkRenderACI("example.com/test03", expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 // Test an image with a pathwhitelist and 2 deps (first without pathWhiteList and the second with pathWhiteList)
@@ -1534,6 +1570,10 @@ func Test2Deps2(t *testing.T) {
 
 	images := Images{image3, image2, image1}
 	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = checkRenderACI("example.com/test03", expectedFiles, ds)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1813,6 +1853,20 @@ func Test3Deps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	err = checkRenderACI("example.com/test04", expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Given an image app name and optional labels, get the best matching image
+// available in the store, build its dependency list and render it inside dir
+func RenderACI(name types.ACName, labels types.Labels, ap ACIRegistry) (map[string]*fileInfo, error) {
+	renderedACI, err := GetRenderedACI(name, labels, ap)
+	if err != nil {
+		return nil, err
+	}
+	return renderImage(renderedACI, ap)
 }
 
 // Given an already populated dependency list, it will extract, under the provided
@@ -1866,6 +1920,19 @@ func renderImage(renderedACI RenderedACI, ap ACIProvider) (map[string]*fileInfo,
 		}
 	}
 	return files, nil
+}
+
+func checkRenderACI(app types.ACName, expectedFiles []*fileInfo, ds *TestStore) error {
+	files, err := RenderACI(app, nil, ds)
+	if err != nil {
+		return err
+	}
+	err = checkExpectedFiles(files, FISliceToMap(expectedFiles))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func checkRenderACIFromList(images Images, expectedFiles []*fileInfo, ds *TestStore) error {

--- a/pkg/acirenderer/acirenderer_test.go
+++ b/pkg/acirenderer/acirenderer_test.go
@@ -1,0 +1,1931 @@
+package acirenderer
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
+)
+
+const tstprefix = "acirenderer-test"
+
+type testTarEntry struct {
+	header   *tar.Header
+	contents string
+}
+
+func newTestTar(entries []*testTarEntry, dir string) (string, error) {
+	t, err := ioutil.TempFile(dir, "tar")
+	if err != nil {
+		return "", err
+	}
+	defer t.Close()
+	tw := tar.NewWriter(t)
+	for _, entry := range entries {
+		// Add default mode
+		if entry.header.Mode == 0 {
+			if entry.header.Typeflag == tar.TypeDir {
+				entry.header.Mode = 0755
+			} else {
+				entry.header.Mode = 0644
+			}
+		}
+		// Add calling user uid and gid or tests will fail
+		entry.header.Uid = os.Getuid()
+		entry.header.Gid = os.Getgid()
+		if err := tw.WriteHeader(entry.header); err != nil {
+			return "", err
+		}
+		if _, err := io.WriteString(tw, entry.contents); err != nil {
+			return "", err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return "", err
+	}
+	return t.Name(), nil
+}
+
+type fileInfo struct {
+	path     string
+	typeflag byte
+	size     int64
+	mode     os.FileMode
+}
+
+func newTestACI(entries []*testTarEntry, dir string, ds *TestStore) (string, error) {
+	testTarPath, err := newTestTar(entries, dir)
+	if err != nil {
+		return "", err
+	}
+
+	key, err := ds.WriteACI(testTarPath)
+	if err != nil {
+		return "", err
+	}
+
+	return key, nil
+}
+
+func createImageManifest(imj string) (*schema.ImageManifest, error) {
+	var im schema.ImageManifest
+	err := im.UnmarshalJSON([]byte(imj))
+	if err != nil {
+		return nil, err
+	}
+	return &im, nil
+}
+
+func addDependencies(imj string, deps ...types.Dependency) (string, error) {
+	im, err := createImageManifest(imj)
+	if err != nil {
+		return "", err
+	}
+
+	for _, dep := range deps {
+		im.Dependencies = append(im.Dependencies, dep)
+	}
+	imjb, err := im.MarshalJSON()
+	return string(imjb), err
+}
+
+func genSimpleImage(imj string, pwl []string, level uint16, dir string, ds *TestStore) (*Image, error) {
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+	}
+	key, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error: %v", err)
+	}
+	im.PathWhitelist = pwl
+	image1 := &Image{Im: im, Key: key, Level: level}
+	return image1, nil
+
+}
+
+func TestGetUpperPWLM(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01"
+		}
+	`
+
+	l0pwl1 := []string{"/a/path/white/list/level0/1"}
+	l1pwl1 := []string{"/a/path/white/list/level1/1"}
+
+	l0pwl1m := pwlToMap(l0pwl1)
+
+	// An image at level 0 with l0pwl1
+	iml0pwl1, err := genSimpleImage(imj, l0pwl1, 0, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// An image at level 0 without pwl
+	iml0nopwl, err := genSimpleImage(imj, []string{}, 0, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// An image at level 1 with l1pwl1
+	iml1pwl1, err := genSimpleImage(imj, l1pwl1, 1, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// An image at level 1 without pwl
+	iml1nopwl, err := genSimpleImage(imj, []string{}, 0, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// An image at level 2 without pwl
+	iml2nopwl, err := genSimpleImage(imj, []string{}, 2, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var emptypwlm map[string]struct{}
+
+	// A (pwl)
+	// Searching for the upper pwlm of A should return nil
+	A := *iml0pwl1
+	images := Images{A}
+	pwlm := getUpperPWLM(images, 0)
+	if !reflect.DeepEqual(pwlm, emptypwlm) {
+		t.Errorf("wrong PathWhitelist, got %#v, want: %#v", pwlm, emptypwlm)
+
+	}
+
+	// A (pwl) ---- B (pwl) --- C
+	// Searching for the upper pwlm of C should return l0pwl1m
+	A = *iml0pwl1
+	B := *iml1pwl1
+	C := *iml2nopwl
+	images = Images{A, B, C}
+	pwlm = getUpperPWLM(images, 2)
+	if !reflect.DeepEqual(pwlm, l0pwl1m) {
+		t.Errorf("wrong PathWhitelist, got %#v, want: %#v", pwlm, l0pwl1m)
+
+	}
+
+	// A ---- B --- D
+	//    \-- C (pwl)
+	// Searching for the upper pwlm of C should return nil
+	A = *iml0nopwl
+	B = *iml1nopwl
+	C = *iml1pwl1
+	D := *iml2nopwl
+	images = Images{A, C, B, D}
+	pwlm = getUpperPWLM(images, 3)
+	if !reflect.DeepEqual(pwlm, emptypwlm) {
+		t.Errorf("wrong PathWhitelist, got %#v, want: %#v", pwlm, emptypwlm)
+	}
+}
+
+// Test an image with 1 dep. The parent provides a dir not provided by the image.
+func TestDirFromParent(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01"
+		}
+	`
+
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// An empty dir
+		{
+			header: &tar.Header{
+				Name:     "rootfs/a",
+				Typeflag: tar.TypeDir,
+			},
+		},
+	}
+
+	key1, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image1 := Image{Im: im, Key: key1, Level: 1}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test02"
+		}
+	`
+
+	k1, _ := types.NewHash(key1)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test01",
+			ImageID: k1},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+	}
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "manifest", typeflag: tar.TypeReg},
+		&fileInfo{path: "rootfs/a", typeflag: tar.TypeDir},
+	}
+
+	key2, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image2 := Image{Im: im, Key: key2, Level: 0}
+
+	images := Images{image2, image1}
+	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Test an image with 1 dep. The image provides a dir not provided by the parent.
+func TestNewDir(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01"
+		}
+	`
+
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// An empty dir
+		{
+			header: &tar.Header{
+				Name:     "rootfs/a",
+				Typeflag: tar.TypeDir,
+			},
+		},
+	}
+
+	key1, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image1 := Image{Im: im, Key: key1, Level: 0}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test02"
+		}
+	`
+
+	k1, _ := types.NewHash(key1)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test01",
+			ImageID: k1},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+	}
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "manifest", typeflag: tar.TypeReg},
+		&fileInfo{path: "rootfs/a", typeflag: tar.TypeDir},
+	}
+
+	key2, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image2 := Image{Im: im, Key: key2, Level: 1}
+
+	images := Images{image2, image1}
+	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Test an image with 1 dep. The image overrides dirs modes from the parent dep. Verifies the right permissions.
+func TestDirOverride(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01"
+		}
+	`
+
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "rootfs/a",
+				Typeflag: tar.TypeDir,
+			},
+		},
+	}
+
+	key1, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image1 := Image{Im: im, Key: key1, Level: 1}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test02"
+		}
+	`
+
+	k1, _ := types.NewHash(key1)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test01",
+			ImageID: k1},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// An empty dir
+		{
+			header: &tar.Header{
+				Name:     "rootfs/a",
+				Typeflag: tar.TypeDir,
+				Mode:     0700,
+			},
+		},
+	}
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "manifest", typeflag: tar.TypeReg},
+		&fileInfo{path: "rootfs/a", typeflag: tar.TypeDir, mode: 0700},
+	}
+
+	key2, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image2 := Image{Im: im, Key: key2, Level: 0}
+
+	images := Images{image2, image1}
+	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Test an image with 1 dep. The parent provides a file not provided by the image.
+func TestFileFromParent(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01"
+		}
+	`
+
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 5,
+			},
+		},
+	}
+
+	key1, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image1 := Image{Im: im, Key: key1, Level: 0}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test02"
+		}
+	`
+
+	k1, _ := types.NewHash(key1)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test01",
+			ImageID: k1},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+	}
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "manifest", typeflag: tar.TypeReg},
+		&fileInfo{path: "rootfs/a/file01.txt", typeflag: tar.TypeReg, size: 5},
+	}
+
+	key2, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image2 := Image{Im: im, Key: key2, Level: 1}
+
+	images := Images{image2, image1}
+	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Test an image with 1 dep. The image provides a file not provided by the parent.
+func TestNewFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01"
+		}
+	`
+
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+	}
+
+	key1, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image1 := Image{Im: im, Key: key1, Level: 0}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test02"
+		}
+	`
+
+	k1, _ := types.NewHash(key1)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test01",
+			ImageID: k1},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		{
+			contents: "hellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 10,
+			},
+		},
+	}
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "manifest", typeflag: tar.TypeReg},
+		&fileInfo{path: "rootfs/a/file01.txt", typeflag: tar.TypeReg, size: 10},
+	}
+
+	key2, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image2 := Image{Im: im, Key: key2, Level: 1}
+
+	images := Images{image2, image1}
+	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Test an image with 1 dep. The image overrides a file already provided by the parent dep.
+func TestFileOverride(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01"
+		}
+	`
+
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 5,
+			},
+		},
+	}
+
+	key1, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image1 := Image{Im: im, Key: key1, Level: 1}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test02"
+		}
+	`
+
+	k1, _ := types.NewHash(key1)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test01",
+			ImageID: k1},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		{
+			contents: "hellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 10,
+			},
+		},
+	}
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "manifest", typeflag: tar.TypeReg},
+		&fileInfo{path: "rootfs/a/file01.txt", typeflag: tar.TypeReg, size: 10},
+	}
+
+	key2, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image2 := Image{Im: im, Key: key2, Level: 0}
+
+	images := Images{image2, image1}
+	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Test an image with 1 dep. The parent image has a pathWhiteList.
+func TestPWLOnlyParent(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01",
+		    "pathWhitelist" : [ "/a/file01.txt", "/a/file02.txt", "/b/link01.txt", "/c/", "/d/" ]
+		}
+	`
+
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 5,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file02.txt",
+				Size: 5,
+			},
+		},
+		// This should not appear in rendered aci
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file03.txt",
+				Size: 5,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "rootfs/b/link01.txt",
+				Linkname: "file01.txt",
+				Typeflag: tar.TypeSymlink,
+			},
+		},
+		// The file "rootfs/c/file01.txt" should not appear but a new file "rootfs/c/file02.txt" provided by the upper image should appear.
+		// The directory should be left with its permissions
+		{
+			header: &tar.Header{
+				Name:     "rootfs/c",
+				Typeflag: tar.TypeDir,
+				Mode:     0700,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/c/file01.txt",
+				Size: 5,
+				Mode: 0700,
+			},
+		},
+		// The file "rootfs/d/file01.txt" should not appear but the directory should be left and also its permissions
+		{
+			header: &tar.Header{
+				Name:     "rootfs/d",
+				Typeflag: tar.TypeDir,
+				Mode:     0700,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/d/file01.txt",
+				Size: 5,
+				Mode: 0700,
+			},
+		},
+		// The file and the directory should not appear
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/e/file01.txt",
+				Size: 5,
+				Mode: 0700,
+			},
+		},
+	}
+
+	key1, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image1 := Image{Im: im, Key: key1, Level: 1}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test02"
+		}
+	`
+
+	k1, _ := types.NewHash(key1)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test01",
+			ImageID: k1},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		{
+			contents: "hellohello",
+			header: &tar.Header{
+				Name: "rootfs/b/file01.txt",
+				Size: 10,
+			},
+		},
+		// New file
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/c/file02.txt",
+				Size: 5,
+			},
+		},
+	}
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "manifest", typeflag: tar.TypeReg},
+		&fileInfo{path: "rootfs/a/file01.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/a/file02.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/b/link01.txt", typeflag: tar.TypeSymlink},
+		&fileInfo{path: "rootfs/b/file01.txt", typeflag: tar.TypeReg, size: 10},
+		&fileInfo{path: "rootfs/c", typeflag: tar.TypeDir, mode: 0700},
+		&fileInfo{path: "rootfs/c/file02.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/d", typeflag: tar.TypeDir, mode: 0700},
+	}
+
+	key2, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image2 := Image{Im: im, Key: key2, Level: 0}
+
+	images := Images{image2, image1}
+	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Test an image with 1 dep. The upper image has a pathWhiteList.
+func TestPWLOnlyImage(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01"
+		}
+	`
+
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// It should be overridden by the one provided by the upper image in rendered aci
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 5,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file02.txt",
+				Size: 5,
+			},
+		},
+		// It should not appear in rendered aci
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file03.txt",
+				Size: 5,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "rootfs/b/link01.txt",
+				Linkname: "file01.txt",
+				Typeflag: tar.TypeSymlink,
+			},
+		},
+		// The file "rootfs/c/file01.txt" should not appear but a new file "rootfs/c/file02.txt" provided by the upper image should appear.
+		{
+			header: &tar.Header{
+				Name:     "rootfs/c",
+				Typeflag: tar.TypeDir,
+				Mode:     0700,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/c/file01.txt",
+				Size: 5,
+				Mode: 0700,
+			},
+		},
+		// The file "rootfs/d/file01.txt" should not appear but the directory should be left and also its permissions
+		{
+			header: &tar.Header{
+				Name:     "rootfs/d",
+				Typeflag: tar.TypeDir,
+				Mode:     0700,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/d/file01.txt",
+				Size: 5,
+				Mode: 0700,
+			},
+		},
+		// The file and the directory should not appear
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/e/file01.txt",
+				Size: 5,
+				Mode: 0700,
+			},
+		},
+	}
+
+	key1, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image1 := Image{Im: im, Key: key1, Level: 1}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test02",
+		    "pathWhitelist" : [ "/a/file01.txt", "/a/file02.txt", "/b/link01.txt", "/b/file01.txt", "/c/file02.txt", "/d/" ]
+		}
+	`
+
+	k1, _ := types.NewHash(key1)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test01",
+			ImageID: k1},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		{
+			contents: "hellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 10,
+			},
+		},
+		// New file
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/c/file02.txt",
+				Size: 5,
+			},
+		},
+	}
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "manifest", typeflag: tar.TypeReg},
+		&fileInfo{path: "rootfs/a/file01.txt", typeflag: tar.TypeReg, size: 10},
+		&fileInfo{path: "rootfs/a/file02.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/b/link01.txt", typeflag: tar.TypeSymlink},
+		&fileInfo{path: "rootfs/c/file02.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/d", typeflag: tar.TypeDir, mode: 0700},
+	}
+
+	key2, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image2 := Image{Im: im, Key: key2, Level: 0}
+
+	images := Images{image2, image1}
+	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Test an image with a pathwhitelist and 2 deps (first with pathWhiteList and the second without pathWhiteList)
+// A (pwl) ---- B (pwl)
+//          \-- C
+func Test2Deps1(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01",
+		    "pathWhitelist" : [ "/a/file01.txt", "/a/file02.txt", "/a/file03.txt", "/a/file04.txt", "/b/link01.txt", "/b/file01.txt" ]
+		}
+	`
+
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// It should be overridden by the one provided by the upper image
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 5,
+			},
+		},
+		// It should be overridden by the one provided by the next dep
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file02.txt",
+				Size: 5,
+			},
+		},
+		// It should remain like this
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file03.txt",
+				Size: 5,
+			},
+		},
+		// It should not appear in rendered aci
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file04.txt",
+				Size: 5,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "rootfs/b/link01.txt",
+				Linkname: "file01.txt",
+				Typeflag: tar.TypeSymlink,
+			},
+		},
+	}
+
+	key1, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image1 := Image{Im: im, Key: key1, Level: 1}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test02"
+		}
+	`
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// It should be overridden by the one provided by the upper image
+		{
+			contents: "hellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 10,
+			},
+		},
+		{
+			contents: "hellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file02.txt",
+				Size: 10,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/b/file01.txt",
+				Size: 5,
+			},
+		},
+	}
+
+	key2, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image2 := Image{Im: im, Key: key2, Level: 1}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test03",
+		    "pathWhitelist" : [ "/a/file01.txt", "/a/file02.txt", "/a/file03.txt", "/b/link01.txt", "/b/file01.txt", "/b/file02.txt", "/c/file01.txt" ]
+		}
+	`
+
+	k1, _ := types.NewHash(key1)
+	k2, _ := types.NewHash(key2)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test01",
+			ImageID: k1},
+		types.Dependency{
+			App:     "example.com/test02",
+			ImageID: k2},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// Overridden
+		{
+			contents: "hellohellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 15,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/b/file02.txt",
+				Size: 5,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/c/file01.txt",
+				Size: 5,
+			},
+		},
+	}
+
+	key3, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image3 := Image{Im: im, Key: key3, Level: 0}
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "manifest", typeflag: tar.TypeReg},
+		&fileInfo{path: "rootfs/a/file01.txt", typeflag: tar.TypeReg, size: 15},
+		&fileInfo{path: "rootfs/a/file02.txt", typeflag: tar.TypeReg, size: 10},
+		&fileInfo{path: "rootfs/a/file03.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/b/link01.txt", typeflag: tar.TypeSymlink},
+		&fileInfo{path: "rootfs/b/file01.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/b/file02.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/c/file01.txt", typeflag: tar.TypeReg, size: 5},
+	}
+
+	images := Images{image3, image2, image1}
+	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Test an image with a pathwhitelist and 2 deps (first without pathWhiteList and the second with pathWhiteList)
+// A (pwl) ---- B
+//          \-- C (pwl)
+func Test2Deps2(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01"
+		}
+	`
+
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// It should be overridden by the one provided by the upper image
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 5,
+			},
+		},
+		// It should be overridden by the one provided by the next dep
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file02.txt",
+				Size: 5,
+			},
+		},
+		// It should remain like this
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file03.txt",
+				Size: 5,
+			},
+		},
+		// It should not appear in rendered aci
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file04.txt",
+				Size: 5,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "rootfs/b/link01.txt",
+				Linkname: "file01.txt",
+				Typeflag: tar.TypeSymlink,
+			},
+		},
+	}
+
+	key1, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image1 := Image{Im: im, Key: key1, Level: 1}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test02",
+		    "pathWhitelist" : [ "/a/file01.txt", "/a/file02.txt", "/b/file01.txt" ]
+		}
+	`
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// It should be overridden by the one provided by the upper image
+		{
+			contents: "hellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 10,
+			},
+		},
+		{
+			contents: "hellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file02.txt",
+				Size: 10,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/b/file01.txt",
+				Size: 5,
+			},
+		},
+	}
+
+	key2, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image2 := Image{Im: im, Key: key2, Level: 1}
+
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test03",
+		    "pathWhitelist" : [ "/a/file01.txt", "/a/file02.txt", "/a/file03.txt", "/b/link01.txt", "/b/file01.txt", "/b/file02.txt", "/c/file01.txt" ]
+		}
+	`
+
+	k1, _ := types.NewHash(key1)
+	k2, _ := types.NewHash(key2)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test01",
+			ImageID: k1},
+		types.Dependency{
+			App:     "example.com/test02",
+			ImageID: k2},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// Overridden
+		{
+			contents: "hellohellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 15,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/b/file02.txt",
+				Size: 5,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/c/file01.txt",
+				Size: 5,
+			},
+		},
+	}
+
+	key3, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image3 := Image{Im: im, Key: key3, Level: 0}
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "manifest", typeflag: tar.TypeReg},
+		&fileInfo{path: "rootfs/a/file01.txt", typeflag: tar.TypeReg, size: 15},
+		&fileInfo{path: "rootfs/a/file02.txt", typeflag: tar.TypeReg, size: 10},
+		&fileInfo{path: "rootfs/a/file03.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/b/link01.txt", typeflag: tar.TypeSymlink},
+		&fileInfo{path: "rootfs/b/file01.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/b/file02.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/c/file01.txt", typeflag: tar.TypeReg, size: 5},
+	}
+
+	images := Images{image3, image2, image1}
+	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Test A (pwl) ---- B
+//               \-- C -- D
+func Test3Deps(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewTestStore()
+
+	// B
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test01"
+		}
+	`
+
+	entries := []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// It should be overridden by the one provided by the upper image
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 5,
+			},
+		},
+		// It should be overridden by the one provided by the next dep
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file02.txt",
+				Size: 5,
+			},
+		},
+		// It should remain like this
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file03.txt",
+				Size: 5,
+			},
+		},
+		// It should not appear in rendered aci
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file04.txt",
+				Size: 5,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "rootfs/b/link01.txt",
+				Linkname: "file01.txt",
+				Typeflag: tar.TypeSymlink,
+			},
+		},
+	}
+
+	key1, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err := createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image1 := Image{Im: im, Key: key1, Level: 1}
+
+	// D
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test03"
+		}
+	`
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// It should be overridden by the one provided by the upper image
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/a/file02.txt",
+				Size: 5,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/b/file01.txt",
+				Size: 5,
+			},
+		},
+		// It should not appear in rendered aci
+		{
+			header: &tar.Header{
+				Name:     "rootfs/d",
+				Typeflag: tar.TypeDir,
+				Mode:     0700,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/d/file01.txt",
+				Size: 5,
+				Mode: 0700,
+			},
+		},
+	}
+
+	key2, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image2 := Image{Im: im, Key: key2, Level: 2}
+
+	// C
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test02"
+		}
+	`
+	k2, _ := types.NewHash(key2)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test03",
+			ImageID: k2},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// It should be overridden by the one provided by the upper image
+		{
+			contents: "hellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 10,
+			},
+		},
+		{
+			contents: "hellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file02.txt",
+				Size: 10,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/b/file01.txt",
+				Size: 5,
+			},
+		},
+	}
+
+	key3, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image3 := Image{Im: im, Key: key3, Level: 1}
+
+	// A
+	imj = `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.1.1",
+		    "name": "example.com/test04",
+		    "pathWhitelist" : [ "/a/file01.txt", "/a/file02.txt", "/a/file03.txt", "/b/link01.txt", "/b/file01.txt", "/b/file02.txt", "/c/file01.txt" ]
+		}
+	`
+
+	k1, _ := types.NewHash(key1)
+	k3, _ := types.NewHash(key3)
+	imj, err = addDependencies(imj,
+		types.Dependency{
+			App:     "example.com/test01",
+			ImageID: k1},
+		types.Dependency{
+			App:     "example.com/test02",
+			ImageID: k3},
+	)
+
+	entries = []*testTarEntry{
+		{
+			contents: imj,
+			header: &tar.Header{
+				Name: "manifest",
+				Size: int64(len(imj)),
+			},
+		},
+		// Overridden
+		{
+			contents: "hellohellohello",
+			header: &tar.Header{
+				Name: "rootfs/a/file01.txt",
+				Size: 15,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/b/file02.txt",
+				Size: 5,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "rootfs/c/file01.txt",
+				Size: 5,
+			},
+		},
+	}
+
+	key4, err := newTestACI(entries, dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	im, err = createImageManifest(imj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image4 := Image{Im: im, Key: key4, Level: 0}
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "manifest", typeflag: tar.TypeReg},
+		&fileInfo{path: "rootfs/a/file01.txt", typeflag: tar.TypeReg, size: 15},
+		&fileInfo{path: "rootfs/a/file02.txt", typeflag: tar.TypeReg, size: 10},
+		&fileInfo{path: "rootfs/a/file03.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/b/link01.txt", typeflag: tar.TypeSymlink},
+		&fileInfo{path: "rootfs/b/file01.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/b/file02.txt", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "rootfs/c/file01.txt", typeflag: tar.TypeReg, size: 5},
+	}
+
+	images := Images{image4, image3, image2, image1}
+	err = checkRenderACIFromList(images, expectedFiles, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Given an already populated dependency list, it will extract, under the provided
+// directory, the rendered ACI
+func RenderACIFromList(imgs Images, ap ACIProvider) (map[string]*fileInfo, error) {
+	renderedACI, err := GetRenderedACIFromList(imgs, ap)
+	if err != nil {
+		return nil, err
+	}
+	return renderImage(renderedACI, ap)
+}
+
+// Given a RenderedACI, it will extract, under the provided directory, the
+// needed files from the right source ACI.
+// The manifest will be extracted from the upper ACI.
+// No file overwriting is done as it should usually be called
+// providing an empty directory.
+func renderImage(renderedACI RenderedACI, ap ACIProvider) (map[string]*fileInfo, error) {
+	files := make(map[string]*fileInfo)
+	for _, ra := range renderedACI {
+		rs, err := ap.ReadStream(ra.Key)
+		if err != nil {
+			return nil, err
+		}
+		defer rs.Close()
+		tr := tar.NewReader(rs)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				// end of tar archive
+				break
+			}
+			if err != nil {
+				return nil, fmt.Errorf("Error reading tar entry: %v", err)
+			}
+			typ := hdr.Typeflag
+			cleanName := filepath.Clean(hdr.Name)
+			if _, ok := ra.FileMap[cleanName]; ok {
+				switch {
+				case typ == tar.TypeReg || typ == tar.TypeRegA:
+					files[cleanName] = &fileInfo{path: cleanName, typeflag: tar.TypeReg, size: hdr.Size, mode: hdr.FileInfo().Mode().Perm()}
+				case typ == tar.TypeDir:
+					files[cleanName] = &fileInfo{path: cleanName, typeflag: tar.TypeDir, mode: hdr.FileInfo().Mode().Perm()}
+				case typ == tar.TypeSymlink:
+					files[cleanName] = &fileInfo{path: cleanName, typeflag: tar.TypeSymlink, mode: hdr.FileInfo().Mode()}
+				default:
+					return nil, fmt.Errorf("wrong type flag: %v\n", typ)
+				}
+			}
+
+		}
+	}
+	return files, nil
+}
+
+func checkRenderACIFromList(images Images, expectedFiles []*fileInfo, ds *TestStore) error {
+	files, err := RenderACIFromList(images, ds)
+	if err != nil {
+		return err
+	}
+	err = checkExpectedFiles(files, FISliceToMap(expectedFiles))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkExpectedFiles(files map[string]*fileInfo, expectedFiles map[string]*fileInfo) error {
+	// Set defaults for not specified expected file mode
+	for _, ef := range expectedFiles {
+		if ef.mode == 0 {
+			if ef.typeflag == tar.TypeDir {
+				ef.mode = 0755
+			} else {
+				ef.mode = 0644
+			}
+		}
+	}
+
+	for _, ef := range expectedFiles {
+		_, ok := files[ef.path]
+		if !ok {
+			return fmt.Errorf("Expected file \"%s\" not in files", ef.path)
+		}
+
+	}
+
+	for _, file := range files {
+		ef, ok := expectedFiles[file.path]
+		if !ok {
+			return fmt.Errorf("file \"%s\" not in expectedFiles", file.path)
+		}
+		if ef.typeflag != file.typeflag {
+			return fmt.Errorf("file \"%s\": file type differs: found %d, wanted: %d", file.path, file.typeflag, ef.typeflag)
+		}
+		if ef.typeflag == tar.TypeReg && file.path != "manifest" {
+			if ef.size != file.size {
+				return fmt.Errorf("file \"%s\": size differs: found %d, wanted: %d", file.path, file.size, ef.size)
+			}
+		}
+		// Check modes but ignore symlinks
+		if ef.mode != file.mode && ef.typeflag != tar.TypeSymlink {
+			return fmt.Errorf("file \"%s\": mode differs: found %#o, wanted: %#o", file.path, file.mode, ef.mode)
+		}
+
+	}
+	return nil
+}
+
+func FISliceToMap(slice []*fileInfo) map[string]*fileInfo {
+	fim := make(map[string]*fileInfo, len(slice))
+	for _, fi := range slice {
+		fim[fi.path] = fi
+	}
+	return fim
+}

--- a/pkg/acirenderer/resolve.go
+++ b/pkg/acirenderer/resolve.go
@@ -1,0 +1,74 @@
+package acirenderer
+
+import (
+	"container/list"
+
+	"github.com/appc/spec/schema/types"
+)
+
+// CreateDepListFromImageID returns the flat dependency tree of the image with
+// the provided imageID
+func CreateDepListFromImageID(imageID types.Hash, ap ACIRegistry) (Images, error) {
+	key, err := ap.ResolveKey(imageID.String())
+	if err != nil {
+		return nil, err
+	}
+	return createDepList(key, ap)
+}
+
+// CreateDepListFromNameLabels returns the flat dependency tree of the image
+// with the provided app name and optional labels.
+func CreateDepListFromNameLabels(name types.ACName, labels types.Labels, ap ACIRegistry) (Images, error) {
+	key, err := ap.GetACI(name, labels)
+	if err != nil {
+		return nil, err
+	}
+	return createDepList(key, ap)
+}
+
+// createDepList returns the flat dependency tree as a list of Image type
+func createDepList(key string, ap ACIRegistry) (Images, error) {
+	imgsl := list.New()
+	im, err := ap.GetImageManifest(key)
+	if err != nil {
+		return nil, err
+	}
+
+	img := Image{Im: im, Key: key, Level: 0}
+	imgsl.PushFront(img)
+
+	// Create a flat dependency tree. Use a LinkedList to be able to
+	// insert elements in the list while working on it.
+	for el := imgsl.Front(); el != nil; el = el.Next() {
+		img := el.Value.(Image)
+		dependencies := img.Im.Dependencies
+		for _, d := range dependencies {
+			var depimg Image
+			var depKey string
+			if d.ImageID != nil && !d.ImageID.Empty() {
+				depKey, err = ap.ResolveKey(d.ImageID.String())
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				var err error
+				depKey, err = ap.GetACI(d.App, d.Labels)
+				if err != nil {
+					return nil, err
+				}
+			}
+			im, err := ap.GetImageManifest(depKey)
+			if err != nil {
+				return nil, err
+			}
+			depimg = Image{Im: im, Key: depKey, Level: img.Level + 1}
+			imgsl.InsertAfter(depimg, el)
+		}
+	}
+
+	imgs := Images{}
+	for el := imgsl.Front(); el != nil; el = el.Next() {
+		imgs = append(imgs, el.Value.(Image))
+	}
+	return imgs, nil
+}

--- a/pkg/acirenderer/store_test.go
+++ b/pkg/acirenderer/store_test.go
@@ -1,0 +1,91 @@
+package acirenderer
+
+import (
+	"bytes"
+	"fmt"
+	"hash"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/appc/spec/aci"
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
+)
+
+const (
+	hashPrefix = "sha512-"
+)
+
+type TestStoreAci struct {
+	data          []byte
+	key           string
+	ImageManifest *schema.ImageManifest
+}
+
+type TestStore struct {
+	acis map[string]*TestStoreAci
+}
+
+func NewTestStore() *TestStore {
+	return &TestStore{acis: make(map[string]*TestStoreAci)}
+}
+
+func (ts *TestStore) WriteACI(path string) (string, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	imageID := types.NewHashSHA512(data)
+
+	rs, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer rs.Close()
+	im, err := aci.ManifestFromImage(rs)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving ImageManifest: %v", err)
+	}
+
+	key := imageID.String()
+	ts.acis[key] = &TestStoreAci{data: data, key: key, ImageManifest: im}
+	return key, nil
+}
+
+func (ts *TestStore) GetImageManifest(key string) (*schema.ImageManifest, error) {
+	aci, ok := ts.acis[key]
+	if !ok {
+		return nil, fmt.Errorf("aci with key: %s not found", key)
+	}
+	return aci.ImageManifest, nil
+
+}
+func (ts *TestStore) GetACI(name types.ACName, labels types.Labels) (string, error) {
+	for _, aci := range ts.acis {
+		if aci.ImageManifest.Name.String() == name.String() {
+			return aci.key, nil
+		}
+	}
+	return "", fmt.Errorf("aci not found")
+}
+
+func (ts *TestStore) ReadStream(key string) (io.ReadCloser, error) {
+	aci, ok := ts.acis[key]
+	if !ok {
+		return nil, fmt.Errorf("stream for key: %s not found", key)
+	}
+	return ioutil.NopCloser(bytes.NewReader(aci.data)), nil
+}
+
+func (ts *TestStore) ResolveKey(key string) (string, error) {
+	return key, nil
+}
+
+// HashToKey takes a hash.Hash (which currently _MUST_ represent a full SHA512),
+// calculates its sum, and returns a string which should be used as the key to
+// store the data matching the hash.
+func (ts *TestStore) HashToKey(h hash.Hash) string {
+	s := h.Sum(nil)
+	return fmt.Sprintf("%s%x", hashPrefix, s)
+}

--- a/test
+++ b/test
@@ -14,7 +14,7 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE_AND_FORMATTABLE="aci discovery pkg/tarheader schema schema/types"
+TESTABLE_AND_FORMATTABLE="aci discovery pkg/acirenderer pkg/tarheader schema schema/types"
 FORMATTABLE="$TESTABLE_AND_FORMATTABLE ace actool"
 
 # user has not provided PKG override


### PR DESCRIPTION
The last patch is the interesting one (the first one is from #216).

This patch generates the dependencies list given an ImageID or an App name and
labels.