### PR TITLE
schema: introduce appOverride to the CRM RuntimeApp

### DIFF
--- a/ace/validator.go
+++ b/ace/validator.go
@@ -394,8 +394,8 @@ func validateAppMetadata(metadataURL string, crm *schema.ContainerRuntimeManifes
 		r = append(r, err)
 	}
 
-	if string(id) != a.ImageID.String() {
-		err = fmt.Errorf("%q's image id mismatch: %v vs %v", string(appName), id, a.ImageID)
+	if string(id) != a.Image.ID.String() {
+		err = fmt.Errorf("%q's image id mismatch: %v vs %v", string(appName), id, a.Image.ID)
 		r = append(r, err)
 	}
 

--- a/examples/container.json
+++ b/examples/container.json
@@ -4,21 +4,57 @@
     "uuid": "6733C088-A507-4694-AABF-EDBE4FC5266F",
     "apps": [
         {
-            "app": "example.com/reduce-worker",
-            "imageID": "sha512-..."
+            "name": "reduce-worker",
+            "image": {
+                "name": "example.com/reduce-worker",
+                "id": "sha512-...",
+                "labels": [
+                    {
+                        "name":  "version",
+                        "value": "1.0.0"
+                    }
+                ]
+            },
+            "app": {
+                "exec": [
+                    "/bin/reduce-worker",
+                    "--debug=true",
+                    "--data-dir=/mnt/foo"
+                ],
+                "group": "0",
+                "user": "0",
+                "mountPoints": [
+                    {
+                        "name": "work",
+                        "path": "/mnt/foo"
+                    }
+                ],
+                "isolators": [
+                    {
+                        "name": "memory/limit",
+                        "value": "1G"
+                    }
+                ]
+            },
+            "mounts": [
+                {"volume": "work", "mountPoint": "work"}
+            ]
         },
         {
-            "app": "example.com/worker-backup",
+            "name": "backup",
+            "image": {
+                "name": "example.com/worker-backup",
+                "id": "sha512-...",
+                "labels": [
+                    {
+                        "name":  "version",
+                        "value": "1.0.0"
+                    }
+                ]
+            },
             "mounts": [
                 {"volume": "database", "mountPoint": "db"},
                 {"volume": "buildoutput", "mountPoint": "out"}
-            ],
-            "imageID": "sha512-...",
-            "isolators": [
-                {
-                    "name": "memory/limit",
-                    "value": "1G"
-                }
             ],
             "annotations": [
                 {
@@ -28,8 +64,17 @@
             ]
         },
         {
-            "app": "example.com/reduce-worker-register",
-            "imageID": "sha512-..."
+            "name": "register",
+            "image": {
+                "name": "example.com/reduce-worker-register",
+                "id": "sha512-...",
+                "labels": [
+                    {
+                        "name":  "version",
+                        "value": "1.0.0"
+                    }
+                ]
+            }
         }
     ],
     "volumes": [

--- a/schema/container.go
+++ b/schema/container.go
@@ -97,8 +97,15 @@ func (r Mount) assertValid() error {
 // RuntimeApp describes an application referenced in a ContainerRuntimeManifest
 type RuntimeApp struct {
 	Name        types.ACName      `json:"name"`
-	ImageID     types.Hash        `json:"imageID"`
+	Image       RuntimeImage      `json:"image"`
+	App         *types.App        `json:"app,omitempty"`
 	Mounts      []Mount           `json:"mounts"`
-	Isolators   []types.Isolator  `json:"isolators"`
 	Annotations types.Annotations `json:"annotations"`
+}
+
+// RuntimeImage describes an image referenced in a RuntimeApp
+type RuntimeImage struct {
+	Name   types.ACName `json:"name"`
+	ID     types.Hash   `json:"id"`
+	Labels types.Labels `json:"labels"`
 }


### PR DESCRIPTION
When the ACE has need for amending the app defaults in any way, it
duplicates the original app object from the image manifest into the
appOverride making amendments to the CRM copy.