### PR TITLE
SPEC: specify only minimum set of environment vars

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -190,13 +190,17 @@ Note that logging mechanisms other than stdout and stderr are not required by th
 
 #### Execution Environment
 
-* **Working directory** defaults to the root of the application image, overridden with "workingDirectory"
+The following environment variables MUST be set for each application's main process and any lifecycle processes:
 * **PATH** `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`
 * **USER, LOGNAME** username of the user executing this app
 * **HOME** home directory of the user
 * **SHELL** login shell of the user
 * **AC_APP_NAME** name of the application, as defined in the image manifest
 * **AC_METADATA_URL** URL where the metadata service for this container can be found
+
+An executor MAY set additional environment variables for the application processes.
+
+Additionally, processes must have their **working directory** set to the value of the application's **workingDirectory** option, if specified, or the root of the application image by default.
 
 ### Isolators
 

--- a/ace/validator.go
+++ b/ace/validator.go
@@ -177,24 +177,14 @@ func ValidateWorkingDirectory(wwd string) (r results) {
 	return
 }
 
-// ValidateEnvironment ensures that the given environment exactly maps the
-// environment in which this process is running
+// ValidateEnvironment ensures that the given environment contains the
+// necessary/expected environment variables.
 func ValidateEnvironment(wenv map[string]string) (r results) {
 	for wkey, wval := range wenv {
 		gval := os.Getenv(wkey)
 		if gval != wval {
 			err := fmt.Errorf("environment variable %q not set as expected (need %q)", wkey, wval)
 			r = append(r, err)
-		}
-	}
-	for _, s := range os.Environ() {
-		parts := strings.SplitN(s, "=", 2)
-		k := parts[0]
-		_, ok := wenv[k]
-		switch {
-		case k == appNameEnv, k == "PATH", k == "TERM", k == "AC_METADATA_URL":
-		case !ok:
-			r = append(r, fmt.Errorf("unexpected environment variable %q set", k))
 		}
 	}
 	return


### PR DESCRIPTION
It is useful for executor implementations to provide various environment 
variables to applications, so the specification should only mandate certain
values rather than the complete set.