### PR TITLE
spec: isolator is name/value pair; name is of ACName type

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -209,8 +209,8 @@ Isolators may be scoped to individual applications, to whole containers, or to b
 Some well known isolators can be verified by the specification.
 Additional isolators will be added to this specification over time.
 
-An isolator is a standalone JSON object with only one required field: "name".
-All other fields are specific to the isolator.
+An isolator is a JSON object with two required fields: "name" and "value".
+"name" is a string restricted to AC Name formatting. "value" can be an arbitrary JSON value.
 
 An executor MAY ignore isolators that it does not understand and run the container without them.
 But, an executor MUST make information about which isolators were ignored, enforced or modified available to the user.

--- a/schema/types/isolator.go
+++ b/schema/types/isolator.go
@@ -2,29 +2,26 @@ package types
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 var (
-	isolatorMap map[string]IsolatorValueConstructor
+	isolatorMap map[ACName]IsolatorValueConstructor
 )
 
 func init() {
-	isolatorMap = make(map[string]IsolatorValueConstructor)
+	isolatorMap = make(map[ACName]IsolatorValueConstructor)
 }
 
 type IsolatorValueConstructor func() IsolatorValue
 
-func AddIsolatorValueConstructor(i IsolatorValueConstructor) {
-	t := i()
-	n := t.Name()
+func AddIsolatorValueConstructor(n ACName, i IsolatorValueConstructor) {
 	isolatorMap[n] = i
 }
 
 type Isolators []Isolator
 
 // GetByName returns the last isolator in the list by the given name.
-func (is *Isolators) GetByName(name string) *Isolator {
+func (is *Isolators) GetByName(name ACName) *Isolator {
 	var i Isolator
 	for j := len(*is) - 1; j >= 0; j-- {
 		i = []Isolator(*is)[j]
@@ -35,13 +32,25 @@ func (is *Isolators) GetByName(name string) *Isolator {
 	return nil
 }
 
+// Unrecognized returns a set of isolators that are not recognized.
+// An isolator is not recognized if it has not had an associated
+// constructor registered with AddIsolatorValueConstructor.
+func (is *Isolators) Unrecognized() Isolators {
+	u := Isolators{}
+	for _, i := range *is {
+		if i.value == nil {
+			u = append(u, i)
+		}
+	}
+	return u
+}
+
 type IsolatorValue interface {
-	Name() string
 	UnmarshalJSON(b []byte) error
 	AssertValid() error
 }
 type Isolator struct {
-	Name     string          `json:"name"`
+	Name     ACName          `json:"name"`
 	ValueRaw json.RawMessage `json:"value"`
 	value    IsolatorValue
 }
@@ -60,24 +69,20 @@ func (i *Isolator) UnmarshalJSON(b []byte) error {
 
 	var dst IsolatorValue
 	con, ok := isolatorMap[ii.Name]
-	if !ok {
-		return errors.New("unrecognized isolator " + ii.Name)
-	}
-	dst = con()
-	err = dst.UnmarshalJSON(ii.ValueRaw)
-	if err != nil {
-		return err
+	if ok {
+		dst = con()
+		err = dst.UnmarshalJSON(ii.ValueRaw)
+		if err != nil {
+			return err
+		}
+		err = dst.AssertValid()
+		if err != nil {
+			return err
+		}
 	}
 
 	i.value = dst
 	i.Name = ii.Name
 
 	return nil
-}
-
-func (i *Isolator) assertValid() error {
-	if i.value == nil {
-		return errors.New("nil Value")
-	}
-	return i.value.AssertValid()
 }

--- a/schema/types/isolator_linux_specific.go
+++ b/schema/types/isolator_linux_specific.go
@@ -6,17 +6,16 @@ import (
 )
 
 const (
-	LinuxCapabilitiesRetainSetName string = "os/linux/capabilities-retain-set"
-	LinuxCapabilitiesRevokeSetName string = "os/linux/capabilities-revoke-set"
+	LinuxCapabilitiesRetainSetName = "os/linux/capabilities-retain-set"
+	LinuxCapabilitiesRevokeSetName = "os/linux/capabilities-revoke-set"
 )
 
 func init() {
-	AddIsolatorValueConstructor(NewLinuxCapabilitiesRetainSet)
-	AddIsolatorValueConstructor(NewLinuxCapabilitiesRevokeSet)
+	AddIsolatorValueConstructor(LinuxCapabilitiesRetainSetName, NewLinuxCapabilitiesRetainSet)
+	AddIsolatorValueConstructor(LinuxCapabilitiesRevokeSetName, NewLinuxCapabilitiesRevokeSet)
 }
 
 type LinuxCapabilitiesSet interface {
-	Name() string
 	Set() []LinuxCapability
 	AssertValid() error
 }
@@ -61,18 +60,10 @@ type LinuxCapabilitiesRetainSet struct {
 	linuxCapabilitiesSetBase
 }
 
-func (l LinuxCapabilitiesRetainSet) Name() string {
-	return LinuxCapabilitiesRetainSetName
-}
-
 func NewLinuxCapabilitiesRevokeSet() IsolatorValue {
 	return &LinuxCapabilitiesRevokeSet{}
 }
 
 type LinuxCapabilitiesRevokeSet struct {
 	linuxCapabilitiesSetBase
-}
-
-func (l LinuxCapabilitiesRevokeSet) Name() string {
-	return LinuxCapabilitiesRevokeSetName
 }

--- a/schema/types/isolator_resources.go
+++ b/schema/types/isolator_resources.go
@@ -22,11 +22,11 @@ const (
 )
 
 func init() {
-	AddIsolatorValueConstructor(NewResourceBlockBandwidth)
-	AddIsolatorValueConstructor(NewResourceBlockIOPS)
-	AddIsolatorValueConstructor(NewResourceCPU)
-	AddIsolatorValueConstructor(NewResourceMemory)
-	AddIsolatorValueConstructor(NewResourceNetworkBandwidth)
+	AddIsolatorValueConstructor(ResourceBlockBandwidthName, NewResourceBlockBandwidth)
+	AddIsolatorValueConstructor(ResourceBlockIOPSName, NewResourceBlockIOPS)
+	AddIsolatorValueConstructor(ResourceCPUName, NewResourceCPU)
+	AddIsolatorValueConstructor(ResourceMemoryName, NewResourceMemory)
+	AddIsolatorValueConstructor(ResourceNetworkBandwidthName, NewResourceNetworkBandwidth)
 }
 
 func NewResourceBlockBandwidth() IsolatorValue {
@@ -93,10 +93,6 @@ func (r ResourceBlockBandwidth) AssertValid() error {
 	return nil
 }
 
-func (r ResourceBlockBandwidth) Name() string {
-	return ResourceBlockBandwidthName
-}
-
 type ResourceBlockIOPS struct {
 	ResourceBase
 }
@@ -111,10 +107,6 @@ func (r ResourceBlockIOPS) AssertValid() error {
 	return nil
 }
 
-func (r ResourceBlockIOPS) Name() string {
-	return ResourceBlockIOPSName
-}
-
 type ResourceCPU struct {
 	ResourceBase
 }
@@ -126,10 +118,6 @@ func (r ResourceCPU) AssertValid() error {
 	return nil
 }
 
-func (r ResourceCPU) Name() string {
-	return ResourceCPUName
-}
-
 type ResourceMemory struct {
 	ResourceBase
 }
@@ -139,10 +127,6 @@ func (r ResourceMemory) AssertValid() error {
 		return ErrDefaultTrue
 	}
 	return nil
-}
-
-func (r ResourceMemory) Name() string {
-	return ResourceMemoryName
 }
 
 type ResourceNetworkBandwidth struct {
@@ -157,8 +141,4 @@ func (r ResourceNetworkBandwidth) AssertValid() error {
 		return ErrRequestNonEmpty
 	}
 	return nil
-}
-
-func (r ResourceNetworkBandwidth) Name() string {
-	return ResourceNetworkBandwidthName
 }


### PR DESCRIPTION
Also reworks isolators to assertValid during unmarshalling
and be tollerant of unrecognized isolators. Added Unrecognized()
method to return unrecognized isolotars for warnings.