### PR TITLE
schema: marshalling of isolators does not work

### DIFF
--- a/schema/types/isolator.go
+++ b/schema/types/isolator.go
@@ -50,8 +50,8 @@ type IsolatorValue interface {
 	AssertValid() error
 }
 type Isolator struct {
-	Name     ACName          `json:"name"`
-	ValueRaw json.RawMessage `json:"value"`
+	Name     ACName           `json:"name"`
+	ValueRaw *json.RawMessage `json:"value"`
 	value    IsolatorValue
 }
 type isolator Isolator
@@ -71,7 +71,7 @@ func (i *Isolator) UnmarshalJSON(b []byte) error {
 	con, ok := isolatorMap[ii.Name]
 	if ok {
 		dst = con()
-		err = dst.UnmarshalJSON(ii.ValueRaw)
+		err = dst.UnmarshalJSON(*ii.ValueRaw)
 		if err != nil {
 			return err
 		}
@@ -82,6 +82,7 @@ func (i *Isolator) UnmarshalJSON(b []byte) error {
 	}
 
 	i.value = dst
+	i.ValueRaw = ii.ValueRaw
 	i.Name = ii.Name
 
 	return nil


### PR DESCRIPTION
Build a valid v0.4.0 image manifest with the following isolator using actool v0.4.0:

```
{
    "name": "os/linux/capabilities-retain-set",
    "value": {
        "set": ["CAP_NET_ADMIN"]
    }
}
```

You will get the following error message:

```
build: Unable to close image workspace/aci/kube-proxy.aci: json: error calling MarshalJSON for type *types.App: json: error calling MarshalJSON for type json.RawMessage: unexpected end of JSON input
```