### PR TITLE
Iaguis/fix validation

### DIFF
--- a/aci/layout.go
+++ b/aci/layout.go
@@ -60,8 +60,7 @@ func ValidateLayout(dir string) error {
 		if err != nil {
 			return err
 		}
-		name := filepath.Base(rpath)
-		switch name {
+		switch rpath {
 		case ".":
 		case ManifestFile:
 			im, err = os.Open(fpath)

--- a/aci/layout.go
+++ b/aci/layout.go
@@ -85,7 +85,7 @@ func ValidateLayout(dir string) error {
 	return validate(imOK, im, rfsOK, flist)
 }
 
-// ValidateLayout takes a *tar.Reader and validates that the layout of the
+// ValidateArchive takes a *tar.Reader and validates that the layout of the
 // filesystem the reader encapsulates matches that expected by the
 // Application Container Image format.  If any errors are encountered during
 // the validation, it will abort and return the first one.

--- a/aci/layout_test.go
+++ b/aci/layout_test.go
@@ -1,0 +1,62 @@
+package aci
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func newValidateLayoutTest() (string, error) {
+	td, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(path.Join(td, "rootfs"), 0755); err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(path.Join(td, "rootfs", "dir", "rootfs"), 0755); err != nil {
+		return "", err
+	}
+
+	evilManifestBody := "malformedManifest"
+	manifestBody := `{"acKind":"ImageManifest","acVersion":"0.3.0","name":"example.com/app"}`
+
+	evilManifestPath := "rootfs/manifest"
+	evilManifestPath = path.Join(td, evilManifestPath)
+
+	em, err := os.Create(evilManifestPath)
+	if err != nil {
+		return "", err
+	}
+
+	em.WriteString(evilManifestBody)
+	em.Close()
+
+	manifestPath := path.Join(td, "manifest")
+
+	m, err := os.Create(manifestPath)
+	if err != nil {
+		return "", err
+	}
+
+	m.WriteString(manifestBody)
+	m.Close()
+
+	return td, nil
+}
+
+func TestValidateLayout(t *testing.T) {
+	layoutPath, err := newValidateLayoutTest()
+	if err != nil {
+		t.Fatalf("newValidateLayoutTest: unexpected error: %v", err)
+	}
+	defer os.RemoveAll(layoutPath)
+
+	err = ValidateLayout(layoutPath)
+	if err != nil {
+		t.Fatalf("ValidateLayout: unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
We should check only the "manifest" and "rootfs/" in the root path of the layout so [using filepath.Base()](https://github.com/appc/spec/blob/80f1c924c5ca698cb15e2119aeb52245f48370ed/aci/layout.go#L63) is wrong.

Also, fix mismatching documentation.

Fixes #236 