### PR TITLE
actool: don't try to open named pipes or sockets

### DIFF
--- a/aci/build.go
+++ b/aci/build.go
@@ -35,6 +35,9 @@ func BuildWalker(root string, aw ArchiveWriter) filepath.WalkFunc {
 		link := ""
 		var r io.Reader
 		switch info.Mode() & os.ModeType {
+		case os.ModeSocket:
+			return nil
+		case os.ModeNamedPipe:
 		case os.ModeCharDevice:
 		case os.ModeDevice:
 		case os.ModeDir:


### PR DESCRIPTION
actool will hang if fifos are opened during build.  sockets probably shouldn't be opened either.