### PR TITLE
schema: replace bool with *bool in types.Volume.

### DIFF
--- a/schema/types/volume.go
+++ b/schema/types/volume.go
@@ -19,7 +19,7 @@ type Volume struct {
 	// currently used only by "host"
 	// TODO(jonboulle): factor out?
 	Source   string `json:"source,omitempty"`
-	ReadOnly bool   `json:"readOnly,omitempty"`
+	ReadOnly *bool  `json:"readOnly,omitempty"`
 }
 
 type volume Volume
@@ -69,7 +69,7 @@ func (v Volume) MarshalJSON() ([]byte, error) {
 }
 
 func (v Volume) String() string {
-	s := fmt.Sprintf("%s,kind=%s,readOnly=%t", v.Name, v.Kind, v.ReadOnly)
+	s := fmt.Sprintf("%s,kind=%s,readOnly=%t", v.Name, v.Kind, *v.ReadOnly)
 	if v.Source != "" {
 		s = s + fmt.Sprintf("source=%s", v.Source)
 	}
@@ -110,7 +110,7 @@ func VolumeFromString(vp string) (*Volume, error) {
 			if err != nil {
 				return nil, err
 			}
-			vol.ReadOnly = ro
+			vol.ReadOnly = &ro
 		default:
 			return nil, fmt.Errorf("unknown volume parameter %q", key)
 		}

--- a/schema/types/volume_test.go
+++ b/schema/types/volume_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestVolumeFromString(t *testing.T) {
+	trueVar := true
+	falseVar := false
 	tests := []struct {
 		s string
 		v Volume
@@ -16,7 +18,16 @@ func TestVolumeFromString(t *testing.T) {
 				Name:     "foobar",
 				Kind:     "host",
 				Source:   "/tmp",
-				ReadOnly: false,
+				ReadOnly: nil,
+			},
+		},
+		{
+			"foobar,kind=host,source=/tmp,readOnly=false",
+			Volume{
+				Name:     "foobar",
+				Kind:     "host",
+				Source:   "/tmp",
+				ReadOnly: &falseVar,
 			},
 		},
 		{
@@ -25,14 +36,15 @@ func TestVolumeFromString(t *testing.T) {
 				Name:     "foobar",
 				Kind:     "host",
 				Source:   "/tmp",
-				ReadOnly: true,
+				ReadOnly: &trueVar,
 			},
 		},
 		{
 			"foobar,kind=empty",
 			Volume{
-				Name: "foobar",
-				Kind: "empty",
+				Name:     "foobar",
+				Kind:     "empty",
+				ReadOnly: nil,
 			},
 		},
 		{
@@ -40,7 +52,7 @@ func TestVolumeFromString(t *testing.T) {
 			Volume{
 				Name:     "foobar",
 				Kind:     "empty",
-				ReadOnly: true,
+				ReadOnly: &trueVar,
 			},
 		},
 	}


### PR DESCRIPTION
Fix https://github.com/coreos/rocket/issues/615

By default the `readOnly` field in Volume is `false`, this will cause
an app container runtime to always override the image manifest's volume
mounts setting. Change it to `*bool` gives us the ability to ignore this
field in the container runtime manifest.
