### PR TITLE
spec: enforce unique app names within a pod

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -868,7 +868,7 @@ JSON Schema for the Pod Manifest, conforming to [RFC4627](https://tools.ietf.org
 * **acVersion** (string, required) represents the version of the schema spec (must be in [semver](http://semver.org/) format)
 * **acKind** (string, required) must be set to "PodManifest"
 * **apps** (list of objects, required) list of apps that will execute inside of this pod. Each app object has the following set of key-value pairs:
-    * **name** (string, optional) name of the app (restricted to AC Name formatting)
+    * **name** (string, required) name of the app (restricted to AC Name formatting). This is used to identify an app within a pod, and hence MUST be unique within the list of apps. This may be different from the name of the underlying image (see below).
     * **image** (object, required) identifiers of the image providing this app
         * **id** (string, required) content hash of the image that this app will execute inside of (must be of the format "type-value", where "type" is "sha512" and value is the hex encoded string of the hash)
         * **name** (string, optional) name of the image (restricted to AC Name formatting)

--- a/SPEC.md
+++ b/SPEC.md
@@ -868,7 +868,7 @@ JSON Schema for the Pod Manifest, conforming to [RFC4627](https://tools.ietf.org
 * **acVersion** (string, required) represents the version of the schema spec (must be in [semver](http://semver.org/) format)
 * **acKind** (string, required) must be set to "PodManifest"
 * **apps** (list of objects, required) list of apps that will execute inside of this pod. Each app object has the following set of key-value pairs:
-    * **name** (string, required) name of the app (restricted to AC Name formatting). This is used to identify an app within a pod, and hence MUST be unique within the list of apps. This may be different from the name of the underlying image (see below).
+    * **name** (string, required) name of the app (restricted to AC Name formatting). This is used to identify an app within a pod, and hence MUST be unique within the list of apps. This may be different from the name of the referenced image (see below); in this way, a pod can have multiple apps using the same underlying image.
     * **image** (object, required) identifiers of the image providing this app
         * **id** (string, required) content hash of the image that this app will execute inside of (must be of the format "type-value", where "type" is "sha512" and value is the hex encoded string of the hash)
         * **name** (string, optional) name of the image (restricted to AC Name formatting)

--- a/schema/pod_test.go
+++ b/schema/pod_test.go
@@ -1,6 +1,10 @@
 package schema
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/appc/spec/schema/types"
+)
 
 func TestPodManifestMerge(t *testing.T) {
 	pmj := `{}`
@@ -15,5 +19,41 @@ func TestPodManifestMerge(t *testing.T) {
 	err := pm.UnmarshalJSON([]byte(pmj))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestAppList(t *testing.T) {
+	ri := RuntimeImage{
+		ID: *types.NewHashSHA512([]byte{}),
+	}
+	al := AppList{
+		RuntimeApp{
+			Name:  "foo",
+			Image: ri,
+		},
+		RuntimeApp{
+			Name:  "bar",
+			Image: ri,
+		},
+	}
+	if _, err := al.MarshalJSON(); err != nil {
+		t.Errorf("want err=nil, got %v", err)
+	}
+	dal := AppList{
+		RuntimeApp{
+			Name:  "foo",
+			Image: ri,
+		},
+		RuntimeApp{
+			Name:  "bar",
+			Image: ri,
+		},
+		RuntimeApp{
+			Name:  "foo",
+			Image: ri,
+		},
+	}
+	if _, err := dal.MarshalJSON(); err == nil {
+		t.Errorf("want err, got nil")
 	}
 }


### PR DESCRIPTION
Since 9aafd97 landed, app references within a pod gained a name field that is
distinct from the name of the underlying image. However, the spec did not
address whether this field needed to be unique, which made it unclear as to
how to facilitate e.g. multiple apps within a pod using the same image.

This makes the name field a) required, and b) unique within a pod.

Accordingly, apps in a running pod can now be uniquely, globally identified by
the combination of Pod UUID + name.

Fixes #84