### PR TITLE
Use types.ACName in parse.App labels name and add a LabelsFromMap function.

### DIFF
--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/appc/spec/schema/types"
 )
 
 func fakeHTTPGet(filename string, failures int) func(uri string) (*http.Response, error) {
@@ -65,7 +67,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			true,
 			App{
 				Name: "example.com/myapp",
-				Labels: map[string]string{
+				Labels: map[types.ACName]string{
 					"version": "1.0.0",
 					"os":      "linux",
 					"arch":    "amd64",
@@ -88,7 +90,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			true,
 			App{
 				Name: "example.com/myapp/foobar",
-				Labels: map[string]string{
+				Labels: map[types.ACName]string{
 					"version": "1.0.0",
 					"os":      "linux",
 					"arch":    "amd64",
@@ -111,7 +113,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			false,
 			App{
 				Name: "example.com/myapp/foobar/bazzer",
-				Labels: map[string]string{
+				Labels: map[types.ACName]string{
 					"version": "1.0.0",
 					"os":      "linux",
 					"arch":    "amd64",
@@ -128,7 +130,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			true,
 			App{
 				Name: "example.com/myapp",
-				Labels: map[string]string{
+				Labels: map[types.ACName]string{
 					"version": "1.0.0",
 				},
 			},
@@ -147,7 +149,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			false,
 			App{
 				Name:   "example.com/myapp",
-				Labels: map[string]string{},
+				Labels: map[types.ACName]string{},
 			},
 			[]ACIEndpoint{
 				ACIEndpoint{
@@ -163,7 +165,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			false,
 			App{
 				Name: "example.com/myapp",
-				Labels: map[string]string{
+				Labels: map[types.ACName]string{
 					"name":    "labelcalledname",
 					"version": "1.0.0",
 				},

--- a/discovery/parse.go
+++ b/discovery/parse.go
@@ -10,12 +10,12 @@ import (
 
 type App struct {
 	Name   types.ACName
-	Labels map[string]string
+	Labels map[types.ACName]string
 }
 
-func NewApp(name string, labels map[string]string) (*App, error) {
+func NewApp(name string, labels map[types.ACName]string) (*App, error) {
 	if labels == nil {
-		labels = make(map[string]string, 0)
+		labels = make(map[types.ACName]string, 0)
 	}
 	acn, err := types.NewACName(name)
 	if err != nil {
@@ -35,7 +35,7 @@ func NewApp(name string, labels map[string]string) (*App, error) {
 func NewAppFromString(app string) (*App, error) {
 	var (
 		name   string
-		labels map[string]string
+		labels map[types.ACName]string
 	)
 
 	app = strings.Replace(app, ":", ",version=", -1)
@@ -44,7 +44,7 @@ func NewAppFromString(app string) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
-	labels = make(map[string]string, 0)
+	labels = make(map[types.ACName]string, 0)
 	for key, val := range v {
 		if len(val) > 1 {
 			return nil, fmt.Errorf("label %s with multiple values %q", key, val)
@@ -53,7 +53,11 @@ func NewAppFromString(app string) (*App, error) {
 			name = val[0]
 			continue
 		}
-		labels[key] = val[0]
+		labelName, err := types.NewACName(key)
+		if err != nil {
+			return nil, err
+		}
+		labels[*labelName] = val[0]
 	}
 	a, err := NewApp(name, labels)
 	if err != nil {

--- a/discovery/parse_test.go
+++ b/discovery/parse_test.go
@@ -3,6 +3,8 @@ package discovery
 import (
 	"reflect"
 	"testing"
+
+	"github.com/appc/spec/schema/types"
 )
 
 func TestNewAppFromString(t *testing.T) {
@@ -17,7 +19,7 @@ func TestNewAppFromString(t *testing.T) {
 
 			&App{
 				Name: "example.com/reduce-worker",
-				Labels: map[string]string{
+				Labels: map[types.ACName]string{
 					"version": "1.0.0",
 				},
 			},
@@ -28,7 +30,7 @@ func TestNewAppFromString(t *testing.T) {
 
 			&App{
 				Name: "example.com/reduce-worker",
-				Labels: map[string]string{
+				Labels: map[types.ACName]string{
 					"channel": "alpha",
 					"label":   "value",
 				},

--- a/schema/types/labels.go
+++ b/schema/types/labels.go
@@ -91,3 +91,14 @@ func (l Labels) Get(name string) (val string, ok bool) {
 	}
 	return "", false
 }
+
+func LabelsFromMap(labelsMap map[ACName]string) (Labels, error) {
+	labels := Labels{}
+	for n, v := range labelsMap {
+		labels = append(labels, Label{Name: n, Value: v})
+	}
+	if err := labels.assertValid(); err != nil {
+		return nil, err
+	}
+	return labels, nil
+}


### PR DESCRIPTION
The first patch changes the discovery.App labels name from a string to a types.ACNAme to be consistent with types.Label.

The second patch will add an utility method to convert the labels map in discovery.App to a types.Labels slice.

This is useful for future rocket patches to avoid adding additional converting code to it.