### PR TITLE
schema/pod: remove UUID field

### DIFF
--- a/schema/pod.go
+++ b/schema/pod.go
@@ -13,7 +13,6 @@ const PodManifestKind = types.ACKind("PodManifest")
 type PodManifest struct {
 	ACVersion   types.SemVer        `json:"acVersion"`
 	ACKind      types.ACKind        `json:"acKind"`
-	UUID        types.UUID          `json:"uuid"`
 	Apps        AppList             `json:"apps"`
 	Volumes     []types.Volume      `json:"volumes"`
 	Isolators   []types.Isolator    `json:"isolators"`


### PR DESCRIPTION
The arrival of pods in #207 removed the UUID field from the PodManifest
(instead requiring that the metadata service expose it), but this was sadly
not reflected in the actual schema code.

/cc @eyakubovich @philips @cdaylward