### PR TITLE
types/acname: add MustACName function

### DIFF
--- a/schema/types/acname.go
+++ b/schema/types/acname.go
@@ -65,6 +65,16 @@ func NewACName(s string) (*ACName, error) {
 	return &n, nil
 }
 
+// MustACName generates a new ACName from a string, If the given string is
+// not a valid ACName, it panics.
+func MustACName(s string) *ACName {
+	n, err := NewACName(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
 func (n ACName) assertValid() error {
 	s := string(n)
 	if len(s) == 0 {

--- a/schema/types/acname_test.go
+++ b/schema/types/acname_test.go
@@ -54,6 +54,29 @@ func TestNewACNameBad(t *testing.T) {
 	}
 }
 
+func TestMustACName(t *testing.T) {
+	for i, in := range goodNames {
+		l := MustACName(in)
+		if l == nil {
+			t.Errorf("#%d: got l=nil, want non-nil", i)
+		}
+	}
+}
+
+func expectPanicMustACName(i int, in string, t *testing.T) {
+	defer func() {
+		recover()
+	}()
+	_ = MustACName(in)
+	t.Errorf("#%d: panic expected", i)
+}
+
+func TestMustACNameBad(t *testing.T) {
+	for i, in := range badNames {
+		expectPanicMustACName(i, in, t)
+	}
+}
+
 func TestSanitizeACName(t *testing.T) {
 	tests := map[string]string{
 		"foo#":                                             "foo",


### PR DESCRIPTION
This function panics when the given string is not a valid ACName. It's
useful for cases where we're sure the ACName we pass is valid.