### PR TITLE
Add App.String() and Labels.ToMap methods.

### DIFF
--- a/discovery/parse.go
+++ b/discovery/parse.go
@@ -65,3 +65,12 @@ func NewAppFromString(app string) (*App, error) {
 	}
 	return a, nil
 }
+
+// String returns the URL-like image name
+func (a *App) String() string {
+	img := a.Name.String()
+	for n, v := range a.Labels {
+		img += fmt.Sprintf(",%s=%s", n, v)
+	}
+	return img
+}

--- a/discovery/parse_test.go
+++ b/discovery/parse_test.go
@@ -74,3 +74,48 @@ func TestNewAppFromString(t *testing.T) {
 		}
 	}
 }
+
+func TestAppString(t *testing.T) {
+	tests := []struct {
+		a   *App
+		out string
+	}{
+		{
+			&App{
+				Name:   "example.com/reduce-worker",
+				Labels: map[types.ACName]string{},
+			},
+			"example.com/reduce-worker",
+		},
+		{
+			&App{
+				Name: "example.com/reduce-worker",
+				Labels: map[types.ACName]string{
+					"version": "1.0.0",
+				},
+			},
+			"example.com/reduce-worker:1.0.0",
+		},
+		{
+			&App{
+				Name: "example.com/reduce-worker",
+				Labels: map[types.ACName]string{
+					"channel": "alpha",
+					"label":   "value",
+				},
+			},
+			"example.com/reduce-worker,channel=alpha,label=value",
+		},
+	}
+	for i, tt := range tests {
+		appString := tt.a.String()
+
+		g, err := NewAppFromString(appString)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(g, tt.a) {
+			t.Errorf("#%d: got %#v, want %#v", i, g, tt.a)
+		}
+	}
+}

--- a/schema/types/labels.go
+++ b/schema/types/labels.go
@@ -92,6 +92,16 @@ func (l Labels) Get(name string) (val string, ok bool) {
 	return "", false
 }
 
+// ToMap creates a map[ACName]string.
+func (l Labels) ToMap() map[ACName]string {
+	labelsMap := make(map[ACName]string)
+	for _, lbl := range l {
+		labelsMap[lbl.Name] = lbl.Value
+	}
+	return labelsMap
+}
+
+// LabelsFromMap creates Labels from a map[ACName]string
 func LabelsFromMap(labelsMap map[ACName]string) (Labels, error) {
 	labels := Labels{}
 	for n, v := range labelsMap {


### PR DESCRIPTION
As discussed in https://github.com/coreos/rkt/pull/661/files#r27144083 this PR adds two new methods useful for future work on rkt for easily converting between manifest data and discovery.App.