### PR TITLE
schema: add linux/aarch64 as valid os/arch

### DIFF
--- a/schema/types/labels.go
+++ b/schema/types/labels.go
@@ -7,7 +7,7 @@ import (
 )
 
 var ValidOSArch = map[string][]string{
-	"linux":   {"amd64", "i386"},
+	"linux":   {"amd64", "i386", "aarch64"},
 	"freebsd": {"amd64", "i386", "arm"},
 	"darwin":  {"x86_64", "i386"},
 }

--- a/schema/types/labels_test.go
+++ b/schema/types/labels_test.go
@@ -16,6 +16,10 @@ func TestLabels(t *testing.T) {
 			"",
 		},
 		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "aarch64"}]`,
+			"",
+		},
+		{
 			`[{"name": "os", "value": "freebsd"}, {"name": "arch", "value": "amd64"}]`,
 			"",
 		},


### PR DESCRIPTION
Following on from discussions in #284 and #287, this adds the `aarch64`
architecture as a valid value for the architecture label when `os` is set to
`linux`.