### PR TITLE
schema: add armv7l/armv7b as valid archs for linux

### DIFF
--- a/schema/types/labels.go
+++ b/schema/types/labels.go
@@ -7,7 +7,7 @@ import (
 )
 
 var ValidOSArch = map[string][]string{
-	"linux":   {"amd64", "i386", "aarch64"},
+	"linux":   {"amd64", "i386", "aarch64", "armv7l", "armv7b"},
 	"freebsd": {"amd64", "i386", "arm"},
 	"darwin":  {"x86_64", "i386"},
 }

--- a/schema/types/labels_test.go
+++ b/schema/types/labels_test.go
@@ -20,12 +20,24 @@ func TestLabels(t *testing.T) {
 			"",
 		},
 		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "armv7l"}]`,
+			"",
+		},
+		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "armv7b"}]`,
+			"",
+		},
+		{
 			`[{"name": "os", "value": "freebsd"}, {"name": "arch", "value": "amd64"}]`,
 			"",
 		},
 		{
 			`[{"name": "os", "value": "OS/360"}, {"name": "arch", "value": "S/360"}]`,
 			`bad os "OS/360"`,
+		},
+		{
+			`[{"name": "os", "value": "freebsd"}, {"name": "arch", "value": "armv7b"}]`,
+			`bad arch "armv7b" for freebsd`,
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "arm"}]`,


### PR DESCRIPTION
After consulting with ARM engineers, it seems the most sensible approach to
architectures pre-aarch64 is to support the two endian variants of ARMv7:
`armv7l` for little-endian and `armv7b` for big-endian.

These also correspond to the output of `uname -m` on Linux systems.

This avoids the somewhat arbitrary armel/armhf/armv7 distinctions
(partly by not accounting for architectures older than ARMv7).


Following up from #287, fixes #284