### PR TITLE
spec: devicePaths parameter missing from examples

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -289,7 +289,7 @@ Small quantities can be represented directly as decimals (e.g., 0.3), or using m
 * Scope: app/pod
 
 **Parameters:**
-* **devicePaths** the block devices that this limit will be placed on
+* **default** must be set to true and means that this limit applies to all block devices by default
 * **limit** read/write bytes per second
 
 ```
@@ -305,7 +305,7 @@ Small quantities can be represented directly as decimals (e.g., 0.3), or using m
 * Scope: app/pod
 
 **Parameters:**
-* **devicePaths** the block devices that this limit will be placed on
+* **default** must be set to true and means that this limit applies to all block devices by default
 * **limit** read/write input/output operations per second
 
 ```


### PR DESCRIPTION
One of the parameters under both "resource/block-bandwidth" and "resource/block-iops" is "devicePaths", however it is not present in the examples, and instead the parameter "default" is present. Perhaps "default" should be replaced with "devicePaths"?