### PR TITLE
pkg: export Makedev helpers

### DIFF
--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -1,0 +1,30 @@
+package device
+
+/*
+#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
+#include <sys/types.h>
+
+unsigned int
+my_major(dev_t dev)
+{
+  return major(dev);
+}
+
+unsigned int
+my_minor(dev_t dev)
+{
+  return minor(dev);
+}
+*/
+import "C"
+
+func Major(rdev uint64) uint {
+	major := C.my_major(C.dev_t(rdev))
+	return uint(major)
+}
+
+func Minor(rdev uint64) uint {
+	minor := C.my_minor(C.dev_t(rdev))
+	return uint(minor)
+}

--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -16,6 +16,12 @@ my_minor(dev_t dev)
 {
   return minor(dev);
 }
+
+dev_t
+my_makedev(unsigned int maj, unsigned int min)
+{
+       return makedev(maj, min);
+}
 */
 import "C"
 
@@ -27,4 +33,9 @@ func Major(rdev uint64) uint {
 func Minor(rdev uint64) uint {
 	minor := C.my_minor(C.dev_t(rdev))
 	return uint(minor)
+}
+
+func Makedev(maj uint, min uint) uint64 {
+	dev := C.my_makedev(C.uint(maj), C.uint(min))
+	return uint64(dev)
 }

--- a/pkg/device/device_posix.go
+++ b/pkg/device/device_posix.go
@@ -1,3 +1,5 @@
+// +build linux freebsd netbsd openbsd
+
 package device
 
 /*

--- a/pkg/tarheader/pop_linux.go
+++ b/pkg/tarheader/pop_linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package tarheader
 
 import (

--- a/pkg/tarheader/pop_posix.go
+++ b/pkg/tarheader/pop_posix.go
@@ -1,3 +1,5 @@
+// +build linux freebsd netbsd openbsd
+
 package tarheader
 
 import (

--- a/pkg/tarheader/pop_posix.go
+++ b/pkg/tarheader/pop_posix.go
@@ -1,28 +1,11 @@
 package tarheader
 
-/*
-#define _BSD_SOURCE
-#define _DEFAULT_SOURCE
-#include <sys/types.h>
-
-unsigned int
-my_major(dev_t dev)
-{
-  return major(dev);
-}
-
-unsigned int
-my_minor(dev_t dev)
-{
-  return minor(dev);
-}
-
-*/
-import "C"
 import (
 	"archive/tar"
 	"os"
 	"syscall"
+
+	"github.com/appc/spec/pkg/device"
 )
 
 func init() {
@@ -37,8 +20,8 @@ func populateHeaderUnix(h *tar.Header, fi os.FileInfo, seen map[uint64]string) {
 	h.Uid = int(st.Uid)
 	h.Gid = int(st.Gid)
 	if st.Mode&syscall.S_IFMT == syscall.S_IFBLK || st.Mode&syscall.S_IFMT == syscall.S_IFCHR {
-		h.Devminor = int64(C.my_minor(C.dev_t(st.Rdev)))
-		h.Devmajor = int64(C.my_major(C.dev_t(st.Rdev)))
+		h.Devminor = int64(device.Minor(st.Rdev))
+		h.Devmajor = int64(device.Major(st.Rdev))
 	}
 	// If we have already seen this inode, generate a hardlink
 	p, ok := seen[uint64(st.Ino)]

--- a/pkg/tarheader/pop_posix_test.go
+++ b/pkg/tarheader/pop_posix_test.go
@@ -1,3 +1,5 @@
+// +build linux freebsd netbsd openbsd
+
 package tarheader
 
 import (


### PR DESCRIPTION
Move them from tarheader to device package and export go functions. This
allows the use of these functions by other packages.

Add makedev function.

This will be used by the CopyTree function I talk about in [coreos/rkt#693 (comment)](https://github.com/coreos/rkt/issues/693#issuecomment-95625786).