### PR TITLE
actool: warn if manifest's ACVersion is too old

### DIFF
--- a/aci/layout.go
+++ b/aci/layout.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
 )
 
 const (
@@ -34,6 +35,14 @@ const (
 	// Path to rootfs directory inside the layout
 	RootfsDir = "rootfs"
 )
+
+type ErrOldVersion struct {
+	version types.SemVer
+}
+
+func (e ErrOldVersion) Error() string {
+	return fmt.Sprintf("ACVersion too old. Found major version %v, expected %v", e.version.Major, schema.AppContainerVersion.Major)
+}
 
 var (
 	ErrNoRootFS   = errors.New("no rootfs found in layout")
@@ -149,6 +158,11 @@ func validate(imOK bool, im io.Reader, rfsOK bool, files []string) error {
 	var a schema.ImageManifest
 	if err := a.UnmarshalJSON(b); err != nil {
 		return fmt.Errorf("image manifest validation failed: %v", err)
+	}
+	if a.ACVersion.LessThanMajor(schema.AppContainerVersion) {
+		return ErrOldVersion{
+			version: a.ACVersion,
+		}
 	}
 	for _, f := range files {
 		if !strings.HasPrefix(f, "rootfs") {

--- a/aci/layout_test.go
+++ b/aci/layout_test.go
@@ -1,10 +1,13 @@
 package aci
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/appc/spec/schema"
 )
 
 func newValidateLayoutTest() (string, error) {
@@ -22,7 +25,7 @@ func newValidateLayoutTest() (string, error) {
 	}
 
 	evilManifestBody := "malformedManifest"
-	manifestBody := `{"acKind":"ImageManifest","acVersion":"0.3.0","name":"example.com/app"}`
+	manifestBody := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"%s","name":"example.com/app"}`, schema.AppContainerVersion)
 
 	evilManifestPath := "rootfs/manifest"
 	evilManifestPath = path.Join(td, evilManifestPath)

--- a/actool/build.go
+++ b/actool/build.go
@@ -48,8 +48,12 @@ func runBuild(args []string) (exit int) {
 
 	// TODO(jonboulle): stream the validation so we don't have to walk the rootfs twice
 	if err := aci.ValidateLayout(root); err != nil {
-		stderr("build: Layout failed validation: %v", err)
-		return 1
+		if e, ok := err.(aci.ErrOldVersion); ok {
+			stderr("build: Warning: %v. Please update your manifest.", e)
+		} else {
+			stderr("build: Layout failed validation: %v", err)
+			return 1
+		}
 	}
 
 	mode := os.O_CREATE | os.O_WRONLY

--- a/actool/build.go
+++ b/actool/build.go
@@ -46,6 +46,12 @@ func runBuild(args []string) (exit int) {
 		return 1
 	}
 
+	// TODO(jonboulle): stream the validation so we don't have to walk the rootfs twice
+	if err := aci.ValidateLayout(root); err != nil {
+		stderr("build: Layout failed validation: %v", err)
+		return 1
+	}
+
 	mode := os.O_CREATE | os.O_WRONLY
 	if buildOverwrite {
 		mode |= os.O_TRUNC
@@ -81,11 +87,6 @@ func runBuild(args []string) (exit int) {
 		}
 	}()
 
-	// TODO(jonboulle): stream the validation so we don't have to walk the rootfs twice
-	if err := aci.ValidateLayout(root); err != nil {
-		stderr("build: Layout failed validation: %v", err)
-		return 1
-	}
 	mpath := filepath.Join(root, aci.ManifestFile)
 	b, err := ioutil.ReadFile(mpath)
 	if err != nil {

--- a/actool/validate.go
+++ b/actool/validate.go
@@ -102,8 +102,12 @@ func runValidate(args []string) (exit int) {
 			err = aci.ValidateArchive(tr)
 			fh.Close()
 			if err != nil {
-				stderr("%s: error validating: %v", path, err)
-				exit = 1
+				if e, ok := err.(aci.ErrOldVersion); ok {
+					stderr("%s: warning: %v", path, e)
+				} else {
+					stderr("%s: error validating: %v", path, err)
+					exit = 1
+				}
 			} else if globalFlags.Debug {
 				stderr("%s: valid app container image", path)
 			}

--- a/schema/types/semver.go
+++ b/schema/types/semver.go
@@ -30,6 +30,21 @@ func NewSemVer(s string) (*SemVer, error) {
 	return &v, nil
 }
 
+func (sv SemVer) LessThanMajor(versionB SemVer) bool {
+	majorA := semver.Version(sv).Major
+	majorB := semver.Version(versionB).Major
+	if majorA < majorB {
+		return true
+	}
+	return false
+}
+
+func (sv SemVer) LessThanExact(versionB SemVer) bool {
+	vA := semver.Version(sv)
+	vB := semver.Version(versionB)
+	return vA.LessThan(vB)
+}
+
 func (sv SemVer) String() string {
 	s := semver.Version(sv)
 	return s.String()


### PR DESCRIPTION
We print a warning if the ACVersion of our input manifest is older than
the current version. This encourages ACI builders to update their
manifests but still allows them to build ACIs with an old ACVersion.