### PR TITLE
Metadata clarification - tokens

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -504,7 +504,8 @@ Clients querying any of these endpoints MUST specify the `Metadata-Flavor: AppCo
 
 ACE implementations SHOULD embed an authorization token in `AC_METADATA_URL`, which provides a means for the metadata service to uniquely and securely identify a pod.
 For example, `AC_METADATA_URL` passed to a pod could be set to `https://10.0.0.1:8888/Y4vFeVZzKM2T9rwkpWHfqXuGsNjS6O5c` with the path portion acting as a token.
-Such a token SHOULD have no fewer than 128 bits of entropy (i.e. size of UUID).
+Since the token is used by the Metadata Service to authenticate the pod's identity, it SHOULD have no fewer than 128 bits of entropy (i.e. size of UUID), and SHOULD NOT be easily guessable (e.g. the pod UUID should not be used).
+
 
 [UUIDs](#pod-uuid) assigned to pods MUST be unique for the administrative domain of the metadata service.
 


### PR DESCRIPTION
Maybe worth clarifying that auth tokens must not be easily discoverable (e.g. don't just use the pod UUID).  Containers will eventually attack hosts or other containers.  This should be tight enough to at least say that containers should have a VERY hard time guessing each others tokens.