### PR TITLE
spec: reconsider SHELL/HOME environment variables

### DIFF
--- a/OS-SPEC.md
+++ b/OS-SPEC.md
@@ -9,10 +9,12 @@ ACIs that define the label `os=linux` can expect this environment by default.
 
 ## Devices and File Systems
 
+The following devices and filesystems MUST be made available in each application's filesystem
+
 |     Path     |  Type  |  Notes  |
 | ------------ | ------ | ------- |
-| /proc        | [procfs](https://www.kernel.org/doc/Documentation/filesystems/proc.txt)   | |
-| /sys         | [sysfs](https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt)     | |
+| /proc        | [procfs](https://www.kernel.org/doc/Documentation/filesystems/proc.txt)    | |
+| /sys         | [sysfs](https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt)    | |
 | /dev/null    | [device](http://man7.org/linux/man-pages/man4/null.4.html)                 | |
 | /dev/zero    | [device](http://man7.org/linux/man-pages/man4/zero.4.html)                 | |
 | /dev/full    | [device](http://man7.org/linux/man-pages/man4/full.4.html)                 | |

--- a/SPEC.md
+++ b/SPEC.md
@@ -207,9 +207,6 @@ Note that logging mechanisms other than stdout and stderr are not required by th
 The following environment variables MUST be set for each application's main process and any lifecycle processes:
 
 * **PATH** `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`
-* **USER, LOGNAME** username of the user executing this app
-* **HOME** home directory of the user
-* **SHELL** login shell of the user
 * **AC_APP_NAME** name of the application, as defined in the image manifest
 * **AC_METADATA_URL** URL where the [metadata service](#app-container-metadata-service) for this pod can be found.
 


### PR DESCRIPTION
As of c8559a283567c1c6840258c6833f5f832fc66cb6 the environment variables mandated by the spec are [as follows]([https://github.com/appc/spec/blob/c8559a283567c1c6840258c6833f5f832fc66cb6/SPEC.md#execution-environment]):
1. `PATH`
2. `USER`
3. `LOGNAME` (same as `USER`)
4. `HOME`
5. `SHELL`
6. `AC_APP_NAME`
7. `AC_METADATA_URL` 

1, 2 and 3 seem relatively uncontroversial - it's reasonable to assume every app executing on a modern OS has these concepts (inherently associated with the process). 6 and 7 are similarly straightforward expectations defined clearly in the spec itself. 

4 and 5 are slightly more problematic because, although part of the POSIX `passwd`, their significance and relevance for applications executing in containers is murky. They are conceptually really associated with an interactive user (--> login session), and it seems to me it should be possible to completely implement the execution side of the appc spec without introducing such a notion. Also, these are traditionally looked up from a database like `/etc/passwd` and it is unclear how this should be discussed (if at all) in the spec. Related: #231

Throwing out a few ideas for clarifying this:
- Declare only that `HOME` and `SHELL` should have "sensible" values but do not have any particular significance or requirements in the spec itself
- Remove `SHELL` entirely from the list of required environment variables ([now that we have relaxed the restrictions on what can be set](https://github.com/appc/spec/pull/228))
- Make `SHELL` optional and mandate (or recommend?) that it be used iff interactive sessions are to be supported
- Stipulate that `HOME` must reference a directory in the rootfs that is writeable by the user (i.e. the `app.User` field)
