### PR TITLE
spec: Rename app name to image name.

### DIFF
--- a/examples/image.json
+++ b/examples/image.json
@@ -76,7 +76,7 @@
     },
     "dependencies": [
         {
-            "app": "example.com/reduce-worker-base",
+            "imageName": "example.com/reduce-worker-base",
             "imageID": "sha512-...",
             "labels": [
                 {

--- a/pkg/acirenderer/acirenderer.go
+++ b/pkg/acirenderer/acirenderer.go
@@ -24,12 +24,12 @@ type ACIRegistry interface {
 
 // An ACIProvider provides functions to get an ACI contents, to convert an
 // ACI hash to the key under which the ACI is known to the provider and to resolve an
-// ImageID to the key under which it's known to the provider.
+// image ID to the key under which it's known to the provider.
 type ACIProvider interface {
 	// Read the ACI contents stream given the key. Use ResolveKey to
-	// convert an ImageID to the relative provider's key.
+	// convert an image ID to the relative provider's key.
 	ReadStream(key string) (io.ReadCloser, error)
-	// Converts an ImageID to the, if existent, key under which the
+	// Converts an image ID to the, if existent, key under which the
 	// ACI is known to the provider
 	ResolveKey(key string) (string, error)
 	// Converts a Hash to the provider's key

--- a/pkg/acirenderer/acirenderer_test.go
+++ b/pkg/acirenderer/acirenderer_test.go
@@ -264,8 +264,8 @@ func TestDirFromParent(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -359,8 +359,8 @@ func TestNewDir(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -453,8 +453,8 @@ func TestDirOverride(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -556,8 +556,8 @@ func TestFileFromParent(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -644,8 +644,8 @@ func TestNewFile(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -746,8 +746,8 @@ func TestFileOverride(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -863,8 +863,8 @@ func TestFileOvverideDir(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -1030,8 +1030,8 @@ func TestPWLOnlyParent(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -1211,8 +1211,8 @@ func TestPWLOnlyImage(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -1412,11 +1412,11 @@ func Test2Deps1(t *testing.T) {
 	k2, _ := types.NewHash(key2)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 		types.Dependency{
-			App:     "example.com/test02",
-			ImageID: k2},
+			ImageName: "example.com/test02",
+			ImageID:   k2},
 	)
 
 	entries = []*testTarEntry{
@@ -1625,11 +1625,11 @@ func Test2Deps2(t *testing.T) {
 	k2, _ := types.NewHash(key2)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 		types.Dependency{
-			App:     "example.com/test02",
-			ImageID: k2},
+			ImageName: "example.com/test02",
+			ImageID:   k2},
 	)
 
 	entries = []*testTarEntry{
@@ -1845,8 +1845,8 @@ func Test3Deps(t *testing.T) {
 	k2, _ := types.NewHash(key2)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test03",
-			ImageID: k2},
+			ImageName: "example.com/test03",
+			ImageID:   k2},
 	)
 
 	entries = []*testTarEntry{
@@ -1905,11 +1905,11 @@ func Test3Deps(t *testing.T) {
 	k3, _ := types.NewHash(key3)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 		types.Dependency{
-			App:     "example.com/test02",
-			ImageID: k3},
+			ImageName: "example.com/test02",
+			ImageID:   k3},
 	)
 
 	entries = []*testTarEntry{

--- a/pkg/acirenderer/resolve.go
+++ b/pkg/acirenderer/resolve.go
@@ -52,7 +52,7 @@ func createDepList(key string, ap ACIRegistry) (Images, error) {
 				}
 			} else {
 				var err error
-				depKey, err = ap.GetACI(d.App, d.Labels)
+				depKey, err = ap.GetACI(d.ImageName, d.Labels)
 				if err != nil {
 					return nil, err
 				}

--- a/schema/types/dependencies.go
+++ b/schema/types/dependencies.go
@@ -8,16 +8,16 @@ import (
 type Dependencies []Dependency
 
 type Dependency struct {
-	App     ACName `json:"app"`
-	ImageID *Hash  `json:"imageID,omitempty"`
-	Labels  Labels `json:"labels,omitempty"`
+	ImageName ACName `json:"imageName"`
+	ImageID   *Hash  `json:"imageID,omitempty"`
+	Labels    Labels `json:"labels,omitempty"`
 }
 
 type dependency Dependency
 
 func (d Dependency) assertValid() error {
-	if len(d.App) < 1 {
-		return errors.New(`App cannot be empty`)
+	if len(d.ImageName) < 1 {
+		return errors.New(`imageName cannot be empty`)
 	}
 	return nil
 }

--- a/schema/types/dependencies_test.go
+++ b/schema/types/dependencies_test.go
@@ -3,7 +3,7 @@ package types
 import "testing"
 
 func TestEmptyHash(t *testing.T) {
-	dj := `{"app": "example.com/reduce-worker-base"}`
+	dj := `{"imageName": "example.com/reduce-worker-base"}`
 
 	var d Dependency
 


### PR DESCRIPTION
Use `app name` in this section seems a little bit out of tune to me. How about changing it to `image name`?

/cc @jonboulle @philips 