### PR TITLE
SPEC: clarify language around the capabilities flags

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -244,7 +244,7 @@ The first example is "capabilities" but this will be expanded to include things 
 
 **Parameters:**
 
-* **set** list of capabilities that will be removed from the process's capabilities bounding set
+* **set** list of capabilities that will be removed from the process's capabilities bounding set, all others will be included.
 
 ```json
 "name": "os/linux/capabilities-remove-set",
@@ -261,7 +261,7 @@ The first example is "capabilities" but this will be expanded to include things 
 
 **Parameters:**
 
-* **set** list of capabilities that will be retained in the process's capabilities bounding set
+* **set** list of capabilities that will be retained in the process's capabilities bounding set, all others will be removed
 
 ```json
 "name": "os/linux/capabilities-retain-set",

--- a/examples/image.json
+++ b/examples/image.json
@@ -54,7 +54,7 @@
                 "value": {"limit": "1G"}
             },
             {
-                "name": "os/linux/capabilities-revoke-set",
+                "name": "os/linux/capabilities-remove-set",
                 "value": {"set": ["CAP_NET_BIND_SERVICE", "CAP_SYS_ADMIN"]}
             }
         ],

--- a/schema/types/isolator_linux_specific.go
+++ b/schema/types/isolator_linux_specific.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	LinuxCapabilitiesRetainSetName = "os/linux/capabilities-retain-set"
-	LinuxCapabilitiesRevokeSetName = "os/linux/capabilities-revoke-set"
+	LinuxCapabilitiesRevokeSetName = "os/linux/capabilities-remove-set"
 )
 
 func init() {

--- a/schema/types/isolator_test.go
+++ b/schema/types/isolator_test.go
@@ -150,7 +150,7 @@ func TestIsolatorsGetByName(t *testing.T) {
 				"value": {"set": ["CAP_KILL"]}
 			},
 			{
-				"name": "os/linux/capabilities-revoke-set",
+				"name": "os/linux/capabilities-remove-set",
 				"value": {"set": ["CAP_KILL"]}
 			}
 		]
@@ -165,7 +165,7 @@ func TestIsolatorsGetByName(t *testing.T) {
 		{"resource/cpu", 1, 30, nil},
 		{"resource/memory", 2147483648, 1000000000, nil},
 		{"os/linux/capabilities-retain-set", 0, 0, []LinuxCapability{"CAP_KILL"}},
-		{"os/linux/capabilities-revoke-set", 0, 0, []LinuxCapability{"CAP_KILL"}},
+		{"os/linux/capabilities-remove-set", 0, 0, []LinuxCapability{"CAP_KILL"}},
 	}
 
 	var is Isolators


### PR DESCRIPTION
This essentially offers two options:

- Remove certain capabilities and include all others
- Retain certain capabilities and removea all others

Fix everything up to be consistent with the remove-set and retain-set
language.