### PR TITLE
Clarify encryption method and add a note about semantic security

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -79,6 +79,8 @@ This set of formats makes it easy to build, host and secure an ACI using technol
 - Image archives SHOULD be signed using PGP, the format MUST be ascii-armored detached signature mode.
 - Image signatures MUST be named with the suffix `.aci.asc`.
 
+**Security Note**: Compressing the image will often change the image size significantly. When encryption is applied after compression, it could lead to information leakage, that would not have been revealed without compression, due to such observable difference. Implementations supporting compression SHOULD include an option to disable compression.
+
 The following example demonstrates the creation of a simple ACI using common command-line tools.
 In this case, the ACI is compressed, encrypted, and signed.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -75,7 +75,7 @@ This set of formats makes it easy to build, host and secure an ACI using technol
 - Image archives MUST have only two top-level pathnames, `manifest` (a regular file) and `rootfs` (a directory). Image archives with additional files outside of `rootfs` are not valid.
 - All files in the image MUST maintain all of their original properties, including timestamps, Unix modes, and extended attributes (xattrs).
 - Image archives MAY be compressed with `gzip`, `bzip2`, or `xz`.
-- Image archives MAY be encrypted with AES symmetric encryption, after (optional) compression/encryption.
+- Image archives MAY be encrypted using PGP symmetric encryption with AES cipher, after optional compression.
 - Image archives SHOULD be signed using PGP, the format MUST be ascii-armored detached signature mode.
 - Image signatures MUST be named with the suffix `.aci.asc`.
 


### PR DESCRIPTION
Make it clear in the spec that the encryption method is based on OpenPGP symmetric AES cipher with 256-bit key. Also add a short note about encryption after compression and a recommendation for implementations to allow disablement of compression.