### PR TITLE
spec: remove CAP_SYS_ADMIN from example manifest

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -673,7 +673,7 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest), conformin
             {
                 "name": "os/linux/capabilities-retain-set",
                 "value": {
-                    "set": ["CAP_NET_BIND_SERVICE", "CAP_SYS_ADMIN"]
+                    "set": ["CAP_NET_BIND_SERVICE"]
                 }
             }
         ],


### PR DESCRIPTION
fixes #389
> CAP_SYS_ADMIN which is quite powerful and should probably be
> discouraged, ie. not given in the example.