### PR TITLE
Allow adding of directories to $PATH

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -218,7 +218,7 @@ The following environment variables MUST be set for each application's main proc
 * **AC_APP_NAME** name of the application, as defined in the image manifest
 * **AC_METADATA_URL** URL where the [metadata service](#app-container-metadata-service) for this pod can be found.
 
-An executor MAY set additional environment variables for the application processes.
+An executor MAY set additional environment variables for the application processes. Also the executor may add additional directories to $PATH of the main process and its descendants, prepended and/or appended to the default directories listed.
 
 Additionally, processes must have their **working directory** set to the value of the application's **workingDirectory** option, if specified, or the root of the application image by default.
 


### PR DESCRIPTION
Proposing to allow the executor to start up the container with additional directories within $PATH.
This would allow a packaging framework which creates the containers to add **different versions** of applications (with potentially forked subprocesses and the like) within in different directories and then to easily switch versions from 'outside', before starting up, by a modified $PATH.
That then _without_ having to check indirections given in proprietary environment variables (which you allow) via wrapper scripts within the container.
