### PR TITLE
discovery: use a copy of app before adding defaultVersion label.

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -110,6 +110,7 @@ func createTemplateVars(app App) []string {
 }
 
 func doDiscover(pre string, app App, insecure bool) (*Endpoints, error) {
+	app = *app.Copy()
 	if app.Labels["version"] == "" {
 		app.Labels["version"] = defaultVersion
 	}

--- a/discovery/parse.go
+++ b/discovery/parse.go
@@ -66,6 +66,17 @@ func NewAppFromString(app string) (*App, error) {
 	return a, nil
 }
 
+func (a *App) Copy() *App {
+	ac := &App{
+		Name:   a.Name,
+		Labels: make(map[types.ACName]string, 0),
+	}
+	for k, v := range a.Labels {
+		ac.Labels[k] = v
+	}
+	return ac
+}
+
 // String returns the URL-like image name
 func (a *App) String() string {
 	img := a.Name.String()

--- a/discovery/parse_test.go
+++ b/discovery/parse_test.go
@@ -119,3 +119,43 @@ func TestAppString(t *testing.T) {
 		}
 	}
 }
+
+func TestAppCopy(t *testing.T) {
+	tests := []struct {
+		a   *App
+		out string
+	}{
+		{
+			&App{
+				Name:   "example.com/reduce-worker",
+				Labels: map[types.ACName]string{},
+			},
+			"example.com/reduce-worker",
+		},
+		{
+			&App{
+				Name: "example.com/reduce-worker",
+				Labels: map[types.ACName]string{
+					"version": "1.0.0",
+				},
+			},
+			"example.com/reduce-worker:1.0.0",
+		},
+		{
+			&App{
+				Name: "example.com/reduce-worker",
+				Labels: map[types.ACName]string{
+					"channel": "alpha",
+					"label":   "value",
+				},
+			},
+			"example.com/reduce-worker,channel=alpha,label=value",
+		},
+	}
+	for i, tt := range tests {
+		appCopy := tt.a.Copy()
+		if !reflect.DeepEqual(appCopy, tt.a) {
+			t.Errorf("#%d: got %#v, want %#v", i, appCopy, tt.a)
+		}
+	}
+}


### PR DESCRIPTION
The discovery.App struct is passed by value to the doDiscover function
but the App.Labels map references the same underlying data structures of
the passed App.Labels map. So adding the "version" label will changes
the passed App.Labels.
Fix this using a copy of discovery.App.