### PR TITLE
discovery: Update the package to expose the http.Client

### DIFF
--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -181,7 +181,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		httpGet = tt.get
+		httpGet = &mockHttpGetter{getter: tt.get}
 		de, _, err := DiscoverEndpoints(tt.app, true)
 		if err != nil && !tt.expectDiscoverySuccess {
 			continue

--- a/discovery/http.go
+++ b/discovery/http.go
@@ -14,10 +14,19 @@ const (
 )
 
 var (
-	// httpGet is the function used by discovery to retrieve URLs; it is
+	// Client is the default http.Client used for discovery requests.
+	Client *http.Client
+
+	// httpGet is the internal object used by discovery to retrieve URLs; it is
 	// defined here so it can be overridden for testing
-	httpGet func(url string) (resp *http.Response, err error)
+	httpGet httpGetter
 )
+
+// httpGetter is an interface used to wrap http.Client for real requests and
+// allow easy mocking in local tests.
+type httpGetter interface {
+	Get(url string) (resp *http.Response, err error)
+}
 
 func init() {
 	t := &http.Transport{
@@ -26,10 +35,10 @@ func init() {
 			return net.DialTimeout(n, a, defaultDialTimeout)
 		},
 	}
-	c := &http.Client{
+	Client = &http.Client{
 		Transport: t,
 	}
-	httpGet = c.Get
+	httpGet = Client
 }
 
 func httpsOrHTTP(name string, insecure bool) (urlStr string, body io.ReadCloser, err error) {
@@ -40,7 +49,7 @@ func httpsOrHTTP(name string, insecure bool) (urlStr string, body io.ReadCloser,
 		}
 		u.RawQuery = "ac-discovery=1"
 		urlStr = u.String()
-		res, err = httpGet(urlStr)
+		res, err = httpGet.Get(urlStr)
 		return
 	}
 	closeBody := func(res *http.Response) {

--- a/discovery/http_test.go
+++ b/discovery/http_test.go
@@ -10,6 +10,15 @@ import (
 	"testing"
 )
 
+// mockHttpGetter defines a wrapper that allows returning a mocked response.
+type mockHttpGetter struct {
+	getter func(url string) (resp *http.Response, err error)
+}
+
+func (m *mockHttpGetter) Get(url string) (resp *http.Response, err error) {
+	return m.getter(url)
+}
+
 func fakeHttpOrHttpsGet(filename string, httpSuccess bool, httpsSuccess bool, httpErrorCode int) func(uri string) (*http.Response, error) {
 	return func(uri string) (*http.Response, error) {
 		f, err := os.Open(filename)
@@ -108,7 +117,7 @@ func TestHttpsOrHTTP(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		httpGet = tt.get
+		httpGet = &mockHttpGetter{getter: tt.get}
 		urlStr, body, err := httpsOrHTTP(tt.name, tt.insecure)
 		if tt.expectSuccess {
 			if err != nil {


### PR DESCRIPTION
This changes the HTTP handling within the discovery package to make its
http.Client an exported field. This has a couple of use cases where consumers
of the package may want to customize the handling, such as:

* Adjusting the dial handler with custom timeouts
* Altering the http.Transport on the client for testing outside of the
  discovery package.
* Altering the proxy used for discovery requests without setting altering the
  proxy settings for the whole process.

This also updates the internal test handling to use an internal interface that
is used to wrap http.Client.Get(). With this, the way the existing tests were
mocking out requests is preserved.