### PR TITLE
spec: dependencies should have "size"/"length"

### DIFF
--- a/schema/types/dependencies.go
+++ b/schema/types/dependencies.go
@@ -11,6 +11,7 @@ type Dependency struct {
 	ImageName ACIdentifier `json:"imageName"`
 	ImageID   *Hash        `json:"imageID,omitempty"`
 	Labels    Labels       `json:"labels,omitempty"`
+	Size      uint         `json:"size,omitempty"`
 }
 
 type dependency Dependency

--- a/spec/aci.md
+++ b/spec/aci.md
@@ -180,7 +180,8 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest), conformin
                     "name": "env",
                     "value": "canary"
                 }
-            ]
+            ],
+            "size": 22017258
         }
     ],
     "pathWhitelist": [
@@ -238,6 +239,7 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest), conformin
     * **imageID** (string of type [Image ID](types.md#image-id-type), optional) content hash of the dependency. If provided, the retrieved dependency must match the hash. This can be used to produce deterministic, repeatable builds of an App Container Image that has dependencies.
     * **labels** (list of objects, optional) a list of the very same form as the aforementioned label objects in the top level ImageManifest. See [Dependency Matching](#dependency-matching) for how these are used.
 * **pathWhitelist** (list of strings, optional) whitelist of absolute paths that will exist in the app's rootfs after rendering. This must be a complete and absolute set. An empty list is equivalent to an absent value and means that all files in this image and any dependencies will be available in the rootfs.
+    * **size** (integer, optional) the size of the image referenced dependency, in bytes. This field is optional; if it is present, the ACE SHOULD ensure it matches when retrieving a dependency, to mitigate "endless data" attacks.
 * **annotations** (list of objects, optional) any extra metadata you wish to add to the image. Each object has two key-value pairs: the *name* is restricted to the [AC Name](types.md#ac-name-type) formatting and *value* is an arbitrary string. Annotation names must be unique within the list. Annotations can be used by systems outside of the ACE (ACE can override). If you are defining new annotations, please consider submitting them to the specification. If you intend for your field to remain special to your application please be a good citizen and prefix an appropriate namespace to your key names. Recognized annotations include:
     * **created** date on which the image was built (string, [timestamps type](types.md#timestamps-type))
     * **authors** contact details of the people or organization responsible for the image (freeform string)


### PR DESCRIPTION
Dependency references should have an optional "size" or "length" field to allow clients to prevent against DOS attacks  ([e.g.](https://github.com/theupdateframework/tuf/blob/d7fd61234e423a30b5ab10253f347fbd515180af/docs/tuf-spec.txt#L138)) when discovering and retrieiving them.