### PR TITLE
Make build scripts work on FreeBSD

### DIFF
--- a/ace/build_aci
+++ b/ace/build_aci
@@ -1,7 +1,8 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
 #
 # Builds an ACI containing a go implementation of an ACE validator
 #
+set -eu
 
 PREFIX="ace"
 
@@ -24,17 +25,21 @@ for typ in main sidekick; do
 		# Set a consistent timestamp so we get a consistent hash
 		# TODO(jonboulle): make this cleaner..
 		for path in rootfs rootfs/ace-validator; do
-			touch -a -m -d 1415660606 ${path}
+			touch -a -m -d 1970-01-01T00:00:00Z ${path}
 		done
 		../actool build --overwrite ./ ../ace-validator-${typ}.aci
 		# TODO(jonboulle): create uncompressed instead, then gzip?
-		HASH=sha512-$(gzip -d -f ../ace-validator-${typ}.aci -c | sha512sum - | awk '{print $1}')
-		gpg --cipher-algo AES256 --output ace-validator-${typ}.aci.asc --detach-sig ../ace-validator-${typ}.aci
-		mv ace-validator-${typ}.aci.asc ../
+		HASH=sha512-$(gzip -d -f ../ace-validator-${typ}.aci -c | openssl dgst -sha512 -hex -r | awk '{print $1}')
+		if [ -z "$NO_SIGNATURE" ] ; then
+			gpg --cipher-algo AES256 --output ace-validator-${typ}.aci.asc --detach-sig ../ace-validator-${typ}.aci
+			mv ace-validator-${typ}.aci.asc ../
+		fi
 	popd >/dev/null
 	echo "Wrote ${typ} layout to      ${layoutdir}"
 	echo "Wrote unsigned ${typ} ACI   bin/ace-validator-${typ}.aci"
 	ln -s ${PWD}/bin/ace-validator-${typ}.aci bin/${HASH}
 	echo "Wrote ${typ} layout hash    bin/${HASH}"
-	echo "Wrote ${typ} ACI signature  bin/ace-validator-${typ}.aci.asc"
+	if [ -f "bin/ace-validator-${typ}.aci.asc" ]; then
+		echo "Wrote ${typ} ACI signature  bin/ace-validator-${typ}.aci.asc"
+	fi
 done

--- a/build
+++ b/build
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 ORG_PATH="github.com/appc"
 REPO_PATH="${ORG_PATH}/spec"
@@ -12,13 +13,21 @@ export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 
 eval $(go env)
+export GOOS GOARCH
+
+if [ "${GOOS}" = "freebsd" ]; then
+    # /usr/bin/cc is clang on freebsd, but we need to tell it to go to
+    # make it generate proper flavour of code that doesn't emit
+    # warnings.
+    export CC=clang
+fi
 
 echo "Building actool..."
 go build -o $GOBIN/actool ${REPO_PATH}/actool
 
-if ! [[ -d "$(go env GOROOT)/pkg/linux_amd64" ]]; then
-	echo "go linux/amd64 not bootstrapped, not building ACE validator"
+if ! [[ -d "$(go env GOROOT)/pkg/${GOOS}_${GOARCH}" ]]; then
+	echo "go ${GOOS}/${GOARCH} not bootstrapped, not building ACE validator"
 else
 	echo "Building ACE validator..."
-	GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -a -installsuffix ace -ldflags '-extldflags "-static"' -o $GOBIN/ace-validator ${REPO_PATH}/ace
+	CGO_ENABLED=0 go build -a -installsuffix ace -ldflags '-extldflags "-static"' -o $GOBIN/ace-validator ${REPO_PATH}/ace
 fi

--- a/test
+++ b/test
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Run all appc tests
 # ./test
@@ -8,6 +8,8 @@
 #
 # PKG=./discovery ./test
 # PKG=schema/types ./test
+
+set -e
 
 # Invoke ./cover for HTML output
 COVER=${COVER:-"-cover"}


### PR DESCRIPTION
Changed build and test scripts to work on FreeBSD. Removed harcoded setting GOOS/GOARCH to Linux/amd64; if cross-compilation is needed, will add an argument to set the target arch.

Are there any instructions on how to use the validator ACIs? A validator pod manifest, maybe?