### PR TITLE
spec: Add schema 'armv6l' as valid arch for linux

### DIFF
--- a/schema/types/labels.go
+++ b/schema/types/labels.go
@@ -7,7 +7,7 @@ import (
 )
 
 var ValidOSArch = map[string][]string{
-	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv7l", "armv7b"},
+	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b"},
 	"freebsd": {"amd64", "i386", "arm"},
 	"darwin":  {"x86_64", "i386"},
 }

--- a/schema/types/labels_test.go
+++ b/schema/types/labels_test.go
@@ -32,6 +32,14 @@ func TestLabels(t *testing.T) {
 			`bad arch "arm64_be" for linux`,
 		},
 		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "arm"}]`,
+			`bad arch "arm" for linux`,
+		},
+		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "armv6l"}]`,
+			"",
+		},
+		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "armv7l"}]`,
 			"",
 		},
@@ -50,10 +58,6 @@ func TestLabels(t *testing.T) {
 		{
 			`[{"name": "os", "value": "freebsd"}, {"name": "arch", "value": "armv7b"}]`,
 			`bad arch "armv7b" for freebsd`,
-		},
-		{
-			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "arm"}]`,
-			`bad arch "arm" for linux`,
 		},
 		{
 			`[{"name": "name"}]`,


### PR DESCRIPTION
This PR brings support for a Raspberry Pi 1. In contrast a Raspberry 2 uses "armv7l" which is already supported in `spec`.

With some more detailed tests I had problems to import ARM Docker images with `docker2aci`. This was due to the fact that Docker uses only `"Os": "linux"` and "`Architecture": "arm"` (can be determined with `docker insect <imageid>`. These issues could be easily solved by adding "arm" as a valid arch.

Fixes #417