### PR TITLE
schema/pod: add GetAppByImageName function

### DIFF
--- a/schema/pod.go
+++ b/schema/pod.go
@@ -112,6 +112,19 @@ func (al AppList) Get(name types.ACName) *RuntimeApp {
 	return nil
 }
 
+// GetAppByImageName retrieves an app from the AppList whose image has the
+// specified name; if there is no such app, nil is returned. The returned
+// *RuntimeApp MUST be considered read-only.
+func (al AppList) GetAppByImageName(name types.ACIdentifier) *RuntimeApp {
+	for _, a := range al {
+		if name.Equals(*a.Image.Name) {
+			aa := a
+			return &aa
+		}
+	}
+	return nil
+}
+
 // Mount describes the mapping between a volume and an apps
 // MountPoint that will be fulfilled at runtime.
 type Mount struct {


### PR DESCRIPTION
This function retrieves an app from the Pod's AppList that has the
specified name in its image.

This function was added to rkt in https://github.com/coreos/rkt/pull/1049