### PR TITLE
ace/validator: update the expected app name to ACName compatible.

### DIFF
--- a/ace/validator.go
+++ b/ace/validator.go
@@ -94,7 +94,7 @@ var (
 		},
 	}
 	// "Name"
-	an = "coreos.com/ace-validator-main"
+	an = "ace-validator-main"
 )
 
 type results []error


### PR DESCRIPTION
fix #447 