### PR TITLE
README.md: Update link to Image Layout section after SPEC.md split

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ App Container is an open-source, community-driven project, developed under the [
 
 ### Building ACIs
 
-`actool` can be used to build an Application Container Image from an [Image Layout](SPEC.md#image-layout) - that is, from an Image Manifest and an application root filesystem (rootfs).
+`actool` can be used to build an Application Container Image from an [Image Layout](spec/aci.md#image-layout) - that is, from an Image Manifest and an application root filesystem (rootfs).
 
 For example, to build a simple ACI (in this case consisting of a single binary), one could do the following:
 ```


### PR DESCRIPTION
Fix link to the Image Layout section which is no longer valid after
commit 9f09e6de0d20 ("*: break spec into discrete sections").

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>