### PR TITLE
aci: make NewCompressedReader an io.ReadCloser

### DIFF
--- a/actool/manifest.go
+++ b/actool/manifest.go
@@ -412,6 +412,7 @@ func runPatchManifest(args []string) (exit int) {
 		stderr("patch-manifest: Cannot extract %s: %v", inputFile, err)
 		return 1
 	}
+	defer tr.Close()
 
 	var newManifest []byte
 
@@ -430,7 +431,7 @@ func runPatchManifest(args []string) (exit int) {
 		}
 	}
 
-	err = extractManifest(tr, tw, false, newManifest)
+	err = extractManifest(tr.Reader, tw, false, newManifest)
 	if err != nil {
 		stderr("patch-manifest: Unable to read %s: %v", inputFile, err)
 		return 1
@@ -467,8 +468,9 @@ func runCatManifest(args []string) (exit int) {
 		stderr("cat-manifest: Cannot extract %s: %v", inputFile, err)
 		return 1
 	}
+	defer tr.Close()
 
-	err = extractManifest(tr, nil, true, nil)
+	err = extractManifest(tr.Reader, nil, true, nil)
 	if err != nil {
 		stderr("cat-manifest: Unable to read %s: %v", inputFile, err)
 		return 1

--- a/actool/validate.go
+++ b/actool/validate.go
@@ -15,12 +15,7 @@
 package main
 
 import (
-	"archive/tar"
-	"compress/bzip2"
-	"compress/gzip"
-	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -107,13 +102,13 @@ func runValidate(args []string) (exit int) {
 				stderr("%s: valid image layout", path)
 			}
 		case typeAppImage:
-			fr, err := maybeDecompress(fh)
+			tr, err := aci.NewCompressedTarReader(fh)
 			if err != nil {
 				stderr("%s: error decompressing file: %v", path, err)
 				return 1
 			}
-			tr := tar.NewReader(fr)
-			err = aci.ValidateArchive(tr)
+			err = aci.ValidateArchive(tr.Reader)
+			tr.Close()
 			fh.Close()
 			if err != nil {
 				stderr("%s: error validating: %v", path, err)
@@ -175,35 +170,4 @@ func detectValType(file *os.File) (string, error) {
 	default:
 		return "", nil
 	}
-}
-
-func maybeDecompress(rs io.ReadSeeker) (io.Reader, error) {
-	// TODO(jonboulle): this is a bit redundant with detectValType
-	typ, err := aci.DetectFileType(rs)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := rs.Seek(0, 0); err != nil {
-		return nil, err
-	}
-	var r io.Reader
-	switch typ {
-	case aci.TypeGzip:
-		r, err = gzip.NewReader(rs)
-		if err != nil {
-			return nil, fmt.Errorf("error reading gzip: %v", err)
-		}
-	case aci.TypeBzip2:
-		r = bzip2.NewReader(rs)
-	case aci.TypeXz:
-		r = aci.XzReader(rs)
-	case aci.TypeTar:
-		r = rs
-	case aci.TypeUnknown:
-		return nil, errors.New("unknown filetype")
-	default:
-		// should never happen
-		panic(fmt.Sprintf("bad type returned from DetectFileType: %v", typ))
-	}
-	return r, nil
 }


### PR DESCRIPTION
now NewCompressedReader returns an io.Reader but gzip.NewReader returns an
io.ReadCloser that was leaked.

This patch makes NewCompressedReader return an io.ReadCloser and wraps others
implementing only io.Reader making them an io.ReadCloser with a fake Close
method.

Consequently NewCompressedTarReader must implement a Close method needed to
close the underlying CompressedReader.

In the meantime duplicated code from actool/validate.go is removed in favor of
the one provided by the aci package.

In another patch also XzReader will be changed to become an io.ReadCloser.

As this is an api change, at least rkt and docker2aci needs to be patched when
updating vendored appc/spec in rkt.