### PR TITLE
aci: make XzReader implement io.ReadCloser

### DIFF
--- a/aci/file.go
+++ b/aci/file.go
@@ -103,25 +103,43 @@ func DetectFileType(r io.Reader) (FileType, error) {
 	}
 }
 
-// XzReader shells out to a command line xz executable (if
+// XzReader is an io.ReadCloser which decompresses xz compressed data.
+type XzReader struct {
+	io.ReadCloser
+	cmd     *exec.Cmd
+	closech chan error
+}
+
+// NewXzReader shells out to a command line xz executable (if
 // available) to decompress the given io.Reader using the xz
-// compression format
-func XzReader(r io.Reader) io.ReadCloser {
+// compression format and returns an *XzReader.
+// It is the caller's responsibility to call Close on the XzReader when done.
+func NewXzReader(r io.Reader) (*XzReader, error) {
 	rpipe, wpipe := io.Pipe()
 	ex, err := exec.LookPath("xz")
 	if err != nil {
 		log.Fatalf("couldn't find xz executable: %v", err)
 	}
 	cmd := exec.Command(ex, "--decompress", "--stdout")
+
+	closech := make(chan error)
+
 	cmd.Stdin = r
 	cmd.Stdout = wpipe
 
 	go func() {
 		err := cmd.Run()
 		wpipe.CloseWithError(err)
+		closech <- err
 	}()
 
-	return rpipe
+	return &XzReader{rpipe, cmd, closech}, nil
+}
+
+func (r *XzReader) Close() error {
+	r.ReadCloser.Close()
+	r.cmd.Process.Kill()
+	return <-r.closech
 }
 
 // ManifestFromImage extracts a new schema.ImageManifest from the given ACI image.
@@ -213,7 +231,10 @@ func NewCompressedReader(rs io.ReadSeeker) (io.ReadCloser, error) {
 	case TypeBzip2:
 		dr = ioutil.NopCloser(bzip2.NewReader(rs))
 	case TypeXz:
-		dr = ioutil.NopCloser(XzReader(rs))
+		dr, err = NewXzReader(rs)
+		if err != nil {
+			return nil, err
+		}
 	case TypeTar:
 		dr = ioutil.NopCloser(rs)
 	case TypeUnknown:

--- a/actool/manifest.go
+++ b/actool/manifest.go
@@ -412,6 +412,7 @@ func runPatchManifest(args []string) (exit int) {
 		stderr("patch-manifest: Cannot extract %s: %v", inputFile, err)
 		return 1
 	}
+	defer tr.Close()
 
 	var newManifest []byte
 
@@ -430,7 +431,7 @@ func runPatchManifest(args []string) (exit int) {
 		}
 	}
 
-	err = extractManifest(tr, tw, false, newManifest)
+	err = extractManifest(tr.Reader, tw, false, newManifest)
 	if err != nil {
 		stderr("patch-manifest: Unable to read %s: %v", inputFile, err)
 		return 1
@@ -467,8 +468,9 @@ func runCatManifest(args []string) (exit int) {
 		stderr("cat-manifest: Cannot extract %s: %v", inputFile, err)
 		return 1
 	}
+	defer tr.Close()
 
-	err = extractManifest(tr, nil, true, nil)
+	err = extractManifest(tr.Reader, nil, true, nil)
 	if err != nil {
 		stderr("cat-manifest: Unable to read %s: %v", inputFile, err)
 		return 1

--- a/actool/validate.go
+++ b/actool/validate.go
@@ -15,12 +15,7 @@
 package main
 
 import (
-	"archive/tar"
-	"compress/bzip2"
-	"compress/gzip"
-	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -107,13 +102,13 @@ func runValidate(args []string) (exit int) {
 				stderr("%s: valid image layout", path)
 			}
 		case typeAppImage:
-			fr, err := maybeDecompress(fh)
+			tr, err := aci.NewCompressedTarReader(fh)
 			if err != nil {
 				stderr("%s: error decompressing file: %v", path, err)
 				return 1
 			}
-			tr := tar.NewReader(fr)
-			err = aci.ValidateArchive(tr)
+			err = aci.ValidateArchive(tr.Reader)
+			tr.Close()
 			fh.Close()
 			if err != nil {
 				stderr("%s: error validating: %v", path, err)
@@ -175,35 +170,4 @@ func detectValType(file *os.File) (string, error) {
 	default:
 		return "", nil
 	}
-}
-
-func maybeDecompress(rs io.ReadSeeker) (io.Reader, error) {
-	// TODO(jonboulle): this is a bit redundant with detectValType
-	typ, err := aci.DetectFileType(rs)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := rs.Seek(0, 0); err != nil {
-		return nil, err
-	}
-	var r io.Reader
-	switch typ {
-	case aci.TypeGzip:
-		r, err = gzip.NewReader(rs)
-		if err != nil {
-			return nil, fmt.Errorf("error reading gzip: %v", err)
-		}
-	case aci.TypeBzip2:
-		r = bzip2.NewReader(rs)
-	case aci.TypeXz:
-		r = aci.XzReader(rs)
-	case aci.TypeTar:
-		r = rs
-	case aci.TypeUnknown:
-		return nil, errors.New("unknown filetype")
-	default:
-		// should never happen
-		panic(fmt.Sprintf("bad type returned from DetectFileType: %v", typ))
-	}
-	return r, nil
 }


### PR DESCRIPTION
this depends on #461. The relevant patch is `aci: make XzReader implement io.ReadCloser`

this is needed as the XzReader, now calling an external process, needs to be
closed or the underlying process will continue to read from the passed file
descriptor, creating a race with subsequent methods calling another XzReader.

The Close method closes the output pipe, kills the process and then waits for
it to exit.

A possible fix after/substituting this will be to migrate to a pure go xz decompressor like the one proposed in #455

This is a part of the fix for coreos/rkt#1224 (missing the rkt part using the right functions)