### PR TITLE
ace/validator: deep compare Statfs_t on FreeBSD

### DIFF
--- a/ace/os_default.go
+++ b/ace/os_default.go
@@ -1,0 +1,9 @@
+// +build !freebsd
+
+package main
+
+import "syscall"
+
+func isSameFilesystem(a, b *syscall.Statfs_t) bool {
+	return a.Fsid == b.Fsid
+}

--- a/ace/os_freebsd.go
+++ b/ace/os_freebsd.go
@@ -1,0 +1,16 @@
+// +build freebsd
+
+package main
+
+import "syscall"
+
+func isSameFilesystem(a, b *syscall.Statfs_t) bool {
+	if a.Fsid != (syscall.Fsid{}) || b.Fsid != (syscall.Fsid{}) {
+		// If Fsid is not empty, we can just compare the IDs
+		return a.Fsid == b.Fsid
+	}
+	// Fsids are zero, this happens in jails, but we can compare the rest
+	return a.Fstypename == b.Fstypename &&
+		a.Mntfromname == b.Mntfromname &&
+		a.Mntonname == b.Mntonname
+}

--- a/ace/validator.go
+++ b/ace/validator.go
@@ -481,7 +481,7 @@ func checkMount(d string, readonly bool) error {
 	if err := syscall.Statfs(filepath.Dir(d), sfs2); err != nil {
 		return fmt.Errorf("error calling statfs on %q: %v", d, err)
 	}
-	if sfs1.Fsid == sfs2.Fsid {
+	if isSameFilesystem(sfs1, sfs2) {
 		return fmt.Errorf("%q is not a mount point", d)
 	}
 	ro := sfs1.Flags&syscall.O_RDONLY == 1


### PR DESCRIPTION
Inside a jail, `Fsid` on bind mounts is `{0,0}` and fails the test.