### PR TITLE
ace/validator: fix mountpoint checks

### DIFF
--- a/ace/os_default.go
+++ b/ace/os_default.go
@@ -1,0 +1,12 @@
+// +build !linux
+// +build !freebsd
+
+package main
+
+import (
+	"syscall"
+)
+
+func isSameFilesystem(a, b *syscall.Statfs_t) bool {
+	return a.Fsid == b.Fsid
+}

--- a/ace/os_freebsd.go
+++ b/ace/os_freebsd.go
@@ -1,0 +1,16 @@
+// +build freebsd
+
+package main
+
+import "syscall"
+
+func isSameFilesystem(a, b *syscall.Statfs_t) bool {
+	if a.Fsid != (syscall.Fsid{}) || b.Fsid != (syscall.Fsid{}) {
+		// If Fsid is not empty, we can just compare the IDs
+		return a.Fsid == b.Fsid
+	}
+	// Fsids are zero, this happens in jails, but we can compare the rest
+	return a.Fstypename == b.Fstypename &&
+		a.Mntfromname == b.Mntfromname &&
+		a.Mntonname == b.Mntonname
+}

--- a/ace/os_linux.go
+++ b/ace/os_linux.go
@@ -1,0 +1,31 @@
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func checkMountImpl(d string, readonly bool) error {
+	mountinfoPath := fmt.Sprintf("/proc/self/mountinfo")
+	mi, err := os.Open(mountinfoPath)
+	if err != nil {
+		return err
+	}
+	defer mi.Close()
+
+	isMounted, ro, err := parseMountinfo(mi, d)
+	if err != nil {
+		return err
+	}
+	if !isMounted {
+		return fmt.Errorf("%q is not a mount point", d)
+	}
+
+	if ro == readonly {
+		return nil
+	} else {
+		return fmt.Errorf("%q mounted ro=%t, want %t", d, ro, readonly)
+	}
+}

--- a/ace/os_shared.go
+++ b/ace/os_shared.go
@@ -1,0 +1,35 @@
+// +build !linux
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"syscall"
+)
+
+func checkMountStatfs(d string, readonly bool) error {
+	// or....
+	// os.Stat(path).Sys().(*syscall.Stat_t).Dev
+	sfs1 := &syscall.Statfs_t{}
+	if err := syscall.Statfs(d, sfs1); err != nil {
+		return fmt.Errorf("error calling statfs on %q: %v", d, err)
+	}
+	sfs2 := &syscall.Statfs_t{}
+	if err := syscall.Statfs(filepath.Dir(d), sfs2); err != nil {
+		return fmt.Errorf("error calling statfs on %q: %v", d, err)
+	}
+	if isSameFilesystem(sfs1, sfs2) {
+		return fmt.Errorf("%q is not a mount point", d)
+	}
+	ro := sfs1.Flags&syscall.O_RDONLY == 1
+	if ro != readonly {
+		return fmt.Errorf("%q mounted ro=%t, want %t", d, ro, readonly)
+	}
+
+	return nil
+}
+
+func checkMountImpl(d string, readonly bool) error {
+	return checkMountStatfs(d, readonly)
+}

--- a/ace/validator_test.go
+++ b/ace/validator_test.go
@@ -1,0 +1,103 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+var mountinfoTests = []struct {
+	mountinfo     string
+	mountPoint    string
+	readOnly      bool
+	expectMounted bool
+	expectErr     bool
+}{
+	{
+		`15 19 0:4 / /proc rw,nosuid,nodev,noexec,relatime shared:5 - proc proc rw
+16 19 0:15 / /sys rw,nosuid,nodev,noexec,relatime shared:6 - sysfs sys rw
+17 19 0:6 / /dev rw,nosuid,relatime shared:2 - devtmpfs dev rw,size=6089152k,nr_inodes=1522288,mode=755
+18 19 0:16 / /run rw,nosuid,nodev,relatime shared:12 - tmpfs run rw,mode=755
+19 0 254:0 / / rw,relatime shared:1 - ext4 /dev/mapper/cryptroot rw,discard,data=ordered
+20 16 0:17 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:7 - securityfs securityfs rw
+21 17 0:18 / /dev/shm rw,nosuid,nodev shared:3 - tmpfs tmpfs rw
+66 19 8:2 / /mountPoint1 rw,relatime,nodev shared:26 slave:88 - ext4 /dev/sda2 rw,discard,data=ordered`,
+		"/mountPoint1",
+		false,
+		true,
+		false,
+	},
+	{
+		`15 19 0:4 / /proc rw,nosuid,nodev,noexec,relatime shared:5 - proc proc rw
+16 19 0:15 / /sys rw,nosuid,nodev,noexec,relatime shared:6 - sysfs sys rw
+17 19 0:6 / /dev rw,nosuid,relatime shared:2 - devtmpfs dev rw,size=6089152k,nr_inodes=1522288,mode=755
+18 19 0:16 / /run rw,nosuid,nodev,relatime shared:12 - tmpfs run rw,mode=755
+66 19 8:2 / /mountPoint2 relatime,ro,nodev shared:26 slave:88 - ext4 /dev/sda2 rw,discard,data=ordered
+19 0 254:0 / / rw,relatime shared:1 - ext4 /dev/mapper/cryptroot rw,discard,data=ordered
+20 16 0:17 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:7 - securityfs securityfs rw
+21 17 0:18 / /dev/shm rw,nosuid,nodev shared:3 - tmpfs tmpfs rw`,
+		"/mountPoint2",
+		true,
+		true,
+		false,
+	},
+	{
+		`15 19 0:4 / /proc rw,nosuid,nodev,noexec,relatime shared:5 - proc proc rw
+16 19 0:15 / /sys rw,nosuid,nodev,noexec,relatime shared:6 - sysfs sys rw
+17 19 0:6 / /dev rw,nosuid,relatime shared:2 - devtmpfs dev rw,size=6089152k,nr_inodes=1522288,mode=755
+18 19 0:16 / /run rw,nosuid,nodev,relatime shared:12 - tmpfs run rw,mode=755
+19 0 254:0 / / rw,relatime shared:1 - ext4 /dev/mapper/cryptroot rw,discard,data=ordered
+20 16 0:17 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:7 - securityfs securityfs rw
+21 17 0:18 / /dev/shm rw,nosuid,nodev shared:3 - tmpfs tmpfs rw`,
+		"/mountPoint3",
+		false,
+		false,
+		false,
+	},
+	{
+		`15 19 0:4 / /proc rw,nosuid,nodev,noexec,relatime shared:5 - proc proc rw
+12 19 8:2 /var/tmp /mountPoint4 rw,relatime,nodev - ext4 /dev/sda2 rw,discard,data=ordered
+16 19 - sys rw
+17 19 0:6 / /dev rw,nosuid,relatime shared:2 - devtmpfs dev rw,size=6089152k,nr_inodes=1522288,mode=755
+18 19 0:16 / /run rw,nosuid,nodev,relatime shared:12 - tmpfs run rw,mode=755
+19 0 254:0 / / rw,relatime shared:1 - ext4 /dev/mapper/cryptroot rw,discard,data=ordered
+20 16 0:17 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:7 - securityfs securityfs rw
+21 17 0:18 / /dev/shm rw,nosuid,nodev shared:3 - tmpfs tmpfs rw`,
+		"/mountPoint4",
+		false,
+		false,
+		true,
+	},
+}
+
+func TestCheckMountLinux(t *testing.T) {
+	for i, mi := range mountinfoTests {
+		isMounted, ro, err := parseMountinfo(strings.NewReader(mi.mountinfo), mi.mountPoint)
+		if err != nil {
+			if mi.expectErr {
+				continue
+			} else {
+				t.Fatalf("#%d: unexpected error: `%v`", i, err)
+			}
+		}
+		if isMounted != mi.expectMounted {
+			t.Fatalf("#%d: expected isMounted=`%v` but got `%v`", i, mi.expectMounted, isMounted)
+		}
+		if ro != mi.readOnly {
+			t.Fatalf("#%d: expected readOnly=`%v` but got `%v`", i, mi.readOnly, ro)
+		}
+	}
+}


### PR DESCRIPTION
This includes:

- A proper check for Linux. The previous one was just checking if the
  devices were the same, this is not true for bind-mounts within the
  same device

- A check for FreeBSD courtesy of Maciej Pasternacki
  <maciej@3ofcoins.net>. Jails seem to have f_fsid set to zero so the
  original check didn't work. Now we check r_fstypename, f_mntfromname
  and f_mntonname too.

- As a fallback (for other systems) we do the same as the original code:
  just check the f_fsid.

Fixes #464 
cc @mpasternacki 