### PR TITLE
spec: Use cpu-core unit in resource/cpu.

### DIFF
--- a/actool/manifest.go
+++ b/actool/manifest.go
@@ -63,7 +63,7 @@ var (
 		  [--capability=CAP_SYS_ADMIN,CAP_NET_ADMIN]
 		  [--mounts=work,path=/opt,readOnly=true[:work2,...]]
 		  [--ports=query,protocol=tcp,port=8080[:query2,...]]
-		  [--isolators=resource/cpu,request=50,limit=100[:resource/memory,...]]
+		  [--isolators=resource/cpu,request=50m,limit=100m[:resource/memory,...]]
 		  [--replace]
 		  INPUT_ACI_FILE
 		  [OUTPUT_ACI_FILE]`,

--- a/examples/image.json
+++ b/examples/image.json
@@ -47,7 +47,7 @@
         "isolators": [
             {
                 "name": "resource/cpu",
-                "value": {"limit": "20"}
+                "value": {"limit": "20m"}
             },
             {
                 "name": "resource/memory",

--- a/schema/types/isolator_test.go
+++ b/schema/types/isolator_test.go
@@ -98,7 +98,7 @@ func TestIsolatorUnmarshal(t *testing.T) {
 		{
 			`{
 				"name": "resource/cpu",
-				"value": {"request": "30", "limit": "1"}
+				"value": {"request": "30m", "limit": "1m"}
 			}`,
 			false,
 		},
@@ -153,7 +153,7 @@ func TestIsolatorsGetByName(t *testing.T) {
 		[
 			{
 				"name": "resource/cpu",
-				"value": {"request": "30", "limit": "1"}
+				"value": {"request": "30m", "limit": "1m"}
 			},
 			{
 				"name": "resource/memory",
@@ -202,9 +202,21 @@ func TestIsolatorsGetByName(t *testing.T) {
 			var r Resource = v
 			glimit := r.Limit()
 			grequest := r.Request()
-			if glimit.Value() != tt.wlimit || grequest.Value() != tt.wrequest {
-				t.Errorf("#%d: glimit=%v, want %v, grequest=%v, want %v", i, glimit.Value(), tt.wlimit, grequest.Value(), tt.wrequest)
+
+			var vlimit, vrequest int64
+			if tt.name == "resource/cpu" {
+				vlimit, vrequest = glimit.MilliValue(), grequest.MilliValue()
+			} else {
+				vlimit, vrequest = glimit.Value(), grequest.Value()
 			}
+
+			if vlimit != tt.wlimit {
+				t.Errorf("#%d: glimit=%v, want %v", i, vlimit, tt.wlimit)
+			}
+			if vrequest != tt.wrequest {
+				t.Errorf("#%d: grequest=%v, want %v", i, vrequest, tt.wrequest)
+			}
+
 		case LinuxCapabilitiesSet:
 			var s LinuxCapabilitiesSet = v
 			if !reflect.DeepEqual(s.Set(), tt.wset) {

--- a/spec/ace.md
+++ b/spec/ace.md
@@ -144,7 +144,7 @@ If the app/pod consumes a resource in excess of its limit, it must be terminated
 Limit and request quantities must always be represented internally (i.e. for encoding and any processing) as an integer value (i.e. NOT floating point) in a resource type's natural base units (e.g., bytes, not megabytes or gigabytes).
 For convenience, when specified by users quantities may either be unsuffixed, have metric suffices (E, P, T, G, M, K) or binary (power-of-two) suffices (Ei, Pi, Ti, Gi, Mi, Ki).
 For example, the following strings represent the same value: "128974848", "125952Ki", "123Mi".
-Sub-units (e.g. decimals, "0.3", or milli-units, "300m") are NOT permissible.
+Small quantities can be represented directly as decimals (e.g., 0.3), or using milli-units (e.g., "300m").
 
 #### resource/block-bandwidth
 
@@ -186,18 +186,18 @@ Sub-units (e.g. decimals, "0.3", or milli-units, "300m") are NOT permissible.
 
 **Parameters:**
 
-* **request** milli-cores that are requested
-* **limit** milli-cores that can be consumed before the kernel temporarily throttles the process
+* **request** cores that are requested
+* **limit** cores that can be consumed before the kernel temporarily throttles the process
 
 ```json
 "name": "resource/cpu",
 "value": {
-  "request": "250",
-  "limit": "500"
+  "request": "250m",
+  "limit": "500m"
 }
 ```
 
-**Note**: a milli-core is the milli-seconds/second that the app/pod will be able to run. e.g. 1000 would represent full use of a single CPU core every second.
+**Note**: a core is the seconds/second that the app/pod will be able to run. e.g. 1 (or 1000m for 1000 milli-seconds) would represent full use of a single CPU core every second.
 
 #### resource/memory
 

--- a/spec/aci.md
+++ b/spec/aci.md
@@ -127,8 +127,8 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest), conformin
             {
                 "name": "resource/cpu",
                 "value": {
-                    "request": "250",
-                    "limit": "500"
+                    "request": "250m",
+                    "limit": "500m"
                 }
             },
             {


### PR DESCRIPTION
This helps us to be consistent with Kubernetes's CPU resource unit.