### PR TITLE
spec: pod: mounts point to path instead of mountPoint

### DIFF
--- a/examples/pod_runtime.json
+++ b/examples/pod_runtime.json
@@ -30,7 +30,7 @@
                 ]
             },
             "mounts": [
-                {"volume": "work", "mountPoint": "work"}
+                {"volume": "work", "path": "/mnt/foo"}
             ]
         },
         {
@@ -46,8 +46,8 @@
                 ]
             },
             "mounts": [
-                {"volume": "database", "mountPoint": "db"},
-                {"volume": "buildoutput", "mountPoint": "out"}
+                {"volume": "database", "path": "/mnt/db"},
+                {"volume": "buildoutput", "path": "/mnt/out"}
             ],
             "annotations": [
                 {

--- a/schema/pod.go
+++ b/schema/pod.go
@@ -126,19 +126,19 @@ func (al AppList) Get(name types.ACName) *RuntimeApp {
 	return nil
 }
 
-// Mount describes the mapping between a volume and an apps
-// MountPoint that will be fulfilled at runtime.
+// Mount describes the mapping between a volume and the path it is mounted
+// inside of an app's filesystem.
 type Mount struct {
-	Volume     types.ACName `json:"volume"`
-	MountPoint types.ACName `json:"mountPoint"`
+	Volume types.ACName `json:"volume"`
+	Path   string       `json:"path"`
 }
 
 func (r Mount) assertValid() error {
 	if r.Volume.Empty() {
 		return errors.New("volume must be set")
 	}
-	if r.MountPoint.Empty() {
-		return errors.New("mountPoint must be set")
+	if r.Path == "" {
+		return errors.New("path must be set")
 	}
 	return nil
 }

--- a/spec/pods.md
+++ b/spec/pods.md
@@ -59,7 +59,7 @@ JSON Schema for the Pod Manifest, conforming to [RFC4627](https://tools.ietf.org
                 ]
             },
             "mounts": [
-                {"volume": "work", "mountPoint": "work"}
+                {"volume": "work", "path": "/mnt/foo"}
             ]
         },
         {
@@ -94,7 +94,7 @@ JSON Schema for the Pod Manifest, conforming to [RFC4627](https://tools.ietf.org
                 ]
             },
             "mounts": [
-                {"volume": "work", "mountPoint": "backup"}
+                {"volume": "work", "path": "/mnt/bar"}
             ],
             "annotations": [
                 {
@@ -159,10 +159,10 @@ JSON Schema for the Pod Manifest, conforming to [RFC4627](https://tools.ietf.org
     * **app** (object, optional) substitute for the app object of the referred image's ImageManifest. See [Image Manifest Schema](aci.md#image-manifest-schema) for what the app object contains.
     * **mounts** (list of objects, optional) list of mounts mapping an app mountPoint to a volume. Each mount has the following set of key-value pairs:
       * **volume** (string, required) name of the volume that will fulfill this mount (restricted to the [AC Name](types.md#ac-name-type) formatting)
-      * **mountPoint** (string, required) name of the app mount point to place the volume on (restricted to the [AC Name](types.md#ac-name-type) formatting)
+      * **path** (string, required) path inside of the app filesystem to mount the volume; generally this will come from one of an apps mountPoint paths
     * **annotations** (list of objects, optional) arbitrary metadata appended to the app. The annotation objects must have a *name* key that has a value that is restricted to the [AC Name](types.md#ac-name-type) formatting and *value* key that is an arbitrary string). Annotation names must be unique within the list. These will be merged with annotations provided by the image manifest when queried via the metadata service; values in this list take precedence over those in the image manifest.
 * **volumes** (list of objects, optional) list of volumes which will be mounted into each application's filesystem
-    * **name** (string, required) used to map the volume to an app's mountPoint at runtime. (restricted to the [AC Name](types.md#ac-name-type) formatting)
+    * **name** (string, required) descriptive label for the volume. (restricted to the [AC Name](types.md#ac-name-type) formatting)
     * **readOnly** (boolean, optional, defaults to "false" if unsupplied) whether or not the volume will be mounted read only.
     * **kind** (string, required) either:
         * **empty** - creates an empty directory on the host and bind mounts it into the container. All containers in the pod share the mount, and the lifetime of the volume is equal to the lifetime of the pod (i.e. the directory on the host machine is removed when the pod's filesystem is garbage collected)


### PR DESCRIPTION
In order to support the use case of mounting at an arbitrary location
inside of the app rootfs we remove the "merge table" between app
mountPoint and volumes. Before, if someone wanted to simply mount over
say /var/log with a volume and that wasn't offered as a mountPoint by
the app the entire app section would need to be overridden.

This does not remove the mountPoint name or volume name so if a runtime
wishes to have this volume/mountPoint map it may still be implemented in
the runtime UX.

This concern was brought up by @thockin in #364.