### PR TITLE
schema: Add a last-ditch parser of pod and image manifests

### DIFF
--- a/schema/lastditch/doc.go
+++ b/schema/lastditch/doc.go
@@ -1,0 +1,28 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package lastditch provides fallback redefinitions of parts of
+// schemas provided by schema package.
+//
+// Almost no validation of schemas is done (besides checking if data
+// really is `JSON`-encoded and kind is either `ImageManifest` or
+// `PodManifest`. This is to get as much data as possible from an
+// invalid manifest. The main aim of the package is to be used for the
+// better error reporting. The another aim might be to force some
+// operation (like removing a pod), which would otherwise fail because
+// of an invalid manifest.
+//
+// To avoid validation during deserialization, types provided by this
+// package use plain strings.
+package lastditch

--- a/schema/lastditch/image.go
+++ b/schema/lastditch/image.go
@@ -1,0 +1,44 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"encoding/json"
+
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
+)
+
+type ImageManifest struct {
+	ACVersion string `json:"acVersion"`
+	ACKind    string `json:"acKind"`
+	Name      string `json:"name"`
+}
+
+// a type just to avoid a recursion during unmarshalling
+type imageManifest ImageManifest
+
+func (im *ImageManifest) UnmarshalJSON(data []byte) error {
+	i := imageManifest(*im)
+	err := json.Unmarshal(data, &i)
+	if err != nil {
+		return err
+	}
+	if i.ACKind != string(schema.ImageManifestKind) {
+		return types.InvalidACKindError(schema.ImageManifestKind)
+	}
+	*im = ImageManifest(i)
+	return nil
+}

--- a/schema/lastditch/image_test.go
+++ b/schema/lastditch/image_test.go
@@ -1,0 +1,70 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/appc/spec/schema/types"
+)
+
+func TestImageManifestWithInvalidName(t *testing.T) {
+	invalidName := "example.com/test!"
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.6.1",
+		    "name": "` + invalidName + `"
+		}
+		`
+	if types.ValidACIdentifier.MatchString(invalidName) {
+		t.Fatalf("%q is an unexpectedly valid name", invalidName)
+	}
+	expected := ImageManifest{
+		ACKind:    "ImageManifest",
+		ACVersion: "0.6.1",
+		Name:      invalidName,
+	}
+	im := ImageManifest{}
+	if err := im.UnmarshalJSON([]byte(imj)); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(im, expected) {
+		t.Errorf("did not get expected image manifest, got: %+v, expected: %+v", im, expected)
+	}
+}
+
+func TestBogusImageManifest(t *testing.T) {
+	bogus := []string{`
+		{
+		    "acKind": "Bogus",
+		    "acVersion": "0.6.1",
+		}
+		`, `
+		<html>
+		    <head>
+		        <title>Certainly not a JSON</title>
+		    </head>
+		</html>`,
+	}
+
+	for _, str := range bogus {
+		im := ImageManifest{}
+		if im.UnmarshalJSON([]byte(str)) == nil {
+			t.Errorf("bogus image manifest unmarshalled successfully: %s", str)
+		}
+	}
+}

--- a/schema/lastditch/pod.go
+++ b/schema/lastditch/pod.go
@@ -1,0 +1,56 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"encoding/json"
+
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
+)
+
+type PodManifest struct {
+	ACVersion string  `json:"acVersion"`
+	ACKind    string  `json:"acKind"`
+	Apps      AppList `json:"apps"`
+}
+
+type AppList []RuntimeApp
+
+type RuntimeApp struct {
+	Name  string `json:"name"`
+	Image Image  `json:"image"`
+}
+
+type Image struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+}
+
+// a type just to avoid a recursion during unmarshalling
+type podManifest PodManifest
+
+func (pm *PodManifest) UnmarshalJSON(data []byte) error {
+	p := podManifest(*pm)
+	err := json.Unmarshal(data, &p)
+	if err != nil {
+		return err
+	}
+	if p.ACKind != string(schema.PodManifestKind) {
+		return types.InvalidACKindError(schema.PodManifestKind)
+	}
+	*pm = PodManifest(p)
+	return nil
+}

--- a/schema/lastditch/pod_test.go
+++ b/schema/lastditch/pod_test.go
@@ -1,0 +1,158 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestInvalidPodManifest(t *testing.T) {
+	// empty image JSON
+	eImgJ := "{}"
+	// empty image instance
+	eImgI := imgI("", "")
+	tests := []struct {
+		desc     string
+		json     string
+		expected PodManifest
+	}{
+		{
+			desc:     "Check an empty pod manifest",
+			json:     podJ("", ""),
+			expected: podI(),
+		},
+		{
+			desc:     "Check a pod manifest with an invalid app name",
+			json:     podJ(appJ("!", eImgJ, ""), ""),
+			expected: podI(appI("!", eImgI)),
+		},
+		{
+			desc:     "Check a pod manifest with duplicated app names",
+			json:     podJ(appJ("a", eImgJ, "")+","+appJ("a", eImgJ, ""), ""),
+			expected: podI(appI("a", eImgI), appI("a", eImgI)),
+		},
+		{
+			desc:     "Check a pod manifest with an invalid image name and ID",
+			json:     podJ(appJ("?", imgJ("!!!", "&&&", ""), ""), ""),
+			expected: podI(appI("?", imgI("!!!", "&&&"))),
+		},
+		{
+			desc:     "Check if we ignore extra fields in a pod",
+			json:     podJ("", `"ports": [],`),
+			expected: podI(),
+		},
+		{
+			desc:     "Check if we ignore extra fields in an app",
+			json:     podJ(appJ("a", eImgJ, `"mounts": [],`), `"ports": [],`),
+			expected: podI(appI("a", eImgI)),
+		},
+		{
+			desc:     "Check if we ignore extra fields in an image",
+			json:     podJ(appJ("a", imgJ("i", "id", `"labels": [],`), `"mounts": [],`), `"ports": [],`),
+			expected: podI(appI("a", imgI("i", "id"))),
+		},
+	}
+	for _, tt := range tests {
+		got := PodManifest{}
+		if err := got.UnmarshalJSON([]byte(tt.json)); err != nil {
+			t.Errorf("%s: unexpected error during unmarshalling pod manifest: %v", tt.desc, err)
+		}
+		if !reflect.DeepEqual(tt.expected, got) {
+			t.Errorf("%s: did not get expected pod manifest, got: %+v, expected: %+v", tt.desc, got, tt.expected)
+		}
+	}
+}
+
+func TestBogusPodManifest(t *testing.T) {
+	bogus := []string{`
+		{
+		    "acKind": "Bogus",
+		    "acVersion": "0.6.1",
+		}
+		`, `
+		<html>
+		    <head>
+		        <title>Certainly not a JSON</title>
+		    </head>
+		</html>`,
+	}
+
+	for _, str := range bogus {
+		pm := PodManifest{}
+		if pm.UnmarshalJSON([]byte(str)) == nil {
+			t.Errorf("bogus pod manifest unmarshalled successfully: %s", str)
+		}
+	}
+}
+
+// podJ returns a pod manifest JSON with given apps
+func podJ(apps, extra string) string {
+	return `
+		{
+		    ` + extra + `
+		    "acKind": "PodManifest",
+		    "acVersion": "0.6.1",
+		    "apps": [` + apps + `]
+		}`
+}
+
+// podI returns a pod manifest instance with given apps
+func podI(apps ...RuntimeApp) PodManifest {
+	if apps == nil {
+		apps = AppList{}
+	}
+	return PodManifest{
+		ACVersion: "0.6.1",
+		ACKind:    "PodManifest",
+		Apps:      apps,
+	}
+}
+
+// appJ returns an app JSON snippet with given name and image
+func appJ(name, image, extra string) string {
+	return `
+		{
+		    ` + extra + `
+		    "name": "` + name + `",
+		    "image": ` + image + `
+		}`
+}
+
+// appI returns an app instance with given name and image
+func appI(name string, image Image) RuntimeApp {
+	return RuntimeApp{
+		Name:  name,
+		Image: image,
+	}
+}
+
+// imgJ returns an image JSON snippet with given name and id
+func imgJ(name, id, extra string) string {
+	return `
+		{
+		    ` + extra + `
+		    "name": "` + name + `",
+		    "id": "` + id + `"
+		}`
+}
+
+// imgI returns an image instance with given name and id
+func imgI(name, id string) Image {
+	return Image{
+		Name: name,
+		ID:   id,
+	}
+}

--- a/test
+++ b/test
@@ -16,7 +16,7 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE_AND_FORMATTABLE="aci discovery pkg/acirenderer pkg/tarheader schema schema/types"
+TESTABLE_AND_FORMATTABLE="aci discovery pkg/acirenderer pkg/tarheader schema schema/lastditch schema/types"
 FORMATTABLE="$TESTABLE_AND_FORMATTABLE ace actool"
 
 # user has not provided PKG override


### PR DESCRIPTION
These do a really minimal validation (only whether the parsed bytes
are indeed JSON and acKind is alright) and get only a part of data
from manifest (names, mostly).

Useful for getting some information about badly-formed manifest for
better error messages.