### PR TITLE
spec: support supplementary GIDs

### DIFF
--- a/schema/types/app.go
+++ b/schema/types/app.go
@@ -22,15 +22,16 @@ import (
 )
 
 type App struct {
-	Exec             Exec           `json:"exec"`
-	EventHandlers    []EventHandler `json:"eventHandlers,omitempty"`
-	User             string         `json:"user"`
-	Group            string         `json:"group"`
-	WorkingDirectory string         `json:"workingDirectory,omitempty"`
-	Environment      Environment    `json:"environment,omitempty"`
-	MountPoints      []MountPoint   `json:"mountPoints,omitempty"`
-	Ports            []Port         `json:"ports,omitempty"`
-	Isolators        Isolators      `json:"isolators,omitempty"`
+	Exec                Exec           `json:"exec"`
+	EventHandlers       []EventHandler `json:"eventHandlers,omitempty"`
+	User                string         `json:"user"`
+	Group               string         `json:"group"`
+	SupplementaryGroups []int          `json:"supplementaryGroups,omitempty"`
+	WorkingDirectory    string         `json:"workingDirectory,omitempty"`
+	Environment         Environment    `json:"environment,omitempty"`
+	MountPoints         []MountPoint   `json:"mountPoints,omitempty"`
+	Ports               []Port         `json:"ports,omitempty"`
+	Isolators           Isolators      `json:"isolators,omitempty"`
 }
 
 // app is a model to facilitate extra validation during the

--- a/spec/aci.md
+++ b/spec/aci.md
@@ -101,6 +101,10 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest), conformin
         ],
         "user": "100",
         "group": "300",
+        "supplementaryGids": [
+                400,
+                500
+        ],
         "eventHandlers": [
             {
                 "exec": [
@@ -221,6 +225,7 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest), conformin
 * **app** (object, optional) if present, defines the default parameters that can be used to execute this image as an application.
     * **exec** (list of strings, required) executable to launch and any flags (must be non-empty; the executable must be an absolute path within the app rootfs; ACE can append or override).  These strings are not evaluated in any way and environment variables are not substituted.
     * **user**, **group** (string, required) indicates either the username/group name or the UID/GID the app is to be run as (freeform string). The user and group values may be all numbers to indicate a UID/GID, however it is possible on some systems (POSIX) to have usernames that are all numerical. The user and group values will first be resolved using the image's own `/etc/passwd` or `/etc/group`. If no valid matches are found, then if the string is all numerical, it shall be converted to an integer and used as the UID/GID. If the user or group field begins with a "/", the owner and group of the file found at that absolute path inside the rootfs is used as the UID/GID of the process. Example values for the fields include `root`, `1000`, or `/usr/bin/ping`.
+    * **supplementaryGids** (list of unsigned integers, optional) indicates additional (supplementary) group IDs (GIDs) as which the app's processes should run.
     * **eventHandlers** (list of objects, optional) allows the app to have several hooks based on lifecycle events. For example, you may want to execute a script before the main process starts up to download a dataset or backup onto the filesystem. An eventHandler is a simple object with two fields - an **exec** (array of strings, ACE can append or override), and a **name** (there may be only one eventHandler of a given name), which must be one of:
         * **pre-start** - executed and must exit before the long running main **exec** binary is launched
         * **post-stop** - executed if the main **exec** process is killed. This can be used to cleanup resources in the case of clean application shutdown, but cannot be relied upon in the face of machine failure.


### PR DESCRIPTION
Image manifest allows me to spec what GID to run as, but does not allow me to add supplemental groups.  This is important for many reasons, not the least of which is disk quota management.