### PR TITLE
ace validator: fix typo in the HTTP-POST options sent to metadata srv

### DIFF
--- a/ace/validator.go
+++ b/ace/validator.go
@@ -429,7 +429,7 @@ func validateSigning(metadataURL string, pm *schema.PodManifest) results {
 	// Verify
 	_, err = metadataPostForm(metadataURL, "/pod/hmac/verify", url.Values{
 		"content":   []string{plaintext},
-		"uid":       []string{string(uuid)},
+		"uuid":      []string{string(uuid)},
 		"signature": []string{string(sig)},
 	})
 


### PR DESCRIPTION
When requesting the metadata service to verify a signature from another pod,
the uuid of the pod needs to be passed as an HTTP-POST option. According to
the spec, the name of the option is "uuid" and not "uid".

