### PR TITLE
last-ditch: Handle labels

### DIFF
--- a/schema/lastditch/common_test.go
+++ b/schema/lastditch/common_test.go
@@ -16,10 +16,42 @@ package lastditch
 
 import (
 	"fmt"
+	"strings"
 )
 
 // extJ returns a JSON snippet describing an extra field with a given
 // name
 func extJ(name string) string {
 	return fmt.Sprintf(`"%s": [],`, name)
+}
+
+// labsJ returns a labels array JSON snippet with given labels
+func labsJ(labels ...string) string {
+	return fmt.Sprintf("[%s]", strings.Join(labels, ","))
+}
+
+// labsI returns a labels array instance with given labels
+func labsI(labels ...Label) Labels {
+	if labels == nil {
+		return Labels{}
+	}
+	return labels
+}
+
+// labJ returns a label JSON snippet with given name and value
+func labJ(name, value, extra string) string {
+	return fmt.Sprintf(`
+		{
+		    %s
+		    "name": "%s",
+		    "value": "%s"
+		}`, extra, name, value)
+}
+
+// labI returns a label instance with given name and value
+func labI(name, value string) Label {
+	return Label{
+		Name:  name,
+		Value: value,
+	}
 }

--- a/schema/lastditch/common_test.go
+++ b/schema/lastditch/common_test.go
@@ -1,0 +1,25 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"fmt"
+)
+
+// extJ returns a JSON snippet describing an extra field with a given
+// name
+func extJ(name string) string {
+	return fmt.Sprintf(`"%s": [],`, name)
+}

--- a/schema/lastditch/image.go
+++ b/schema/lastditch/image.go
@@ -25,6 +25,7 @@ type ImageManifest struct {
 	ACVersion string `json:"acVersion"`
 	ACKind    string `json:"acKind"`
 	Name      string `json:"name"`
+	Labels    Labels `json:"labels,omitempty"`
 }
 
 // a type just to avoid a recursion during unmarshalling

--- a/schema/lastditch/image_test.go
+++ b/schema/lastditch/image_test.go
@@ -15,35 +15,61 @@
 package lastditch
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
-
-	"github.com/appc/spec/schema/types"
 )
 
-func TestImageManifestWithInvalidName(t *testing.T) {
-	invalidName := "example.com/test!"
-	imj := `
+func TestInvalidImageManifest(t *testing.T) {
+	tests := []struct {
+		desc     string
+		json     string
+		expected ImageManifest
+	}{
 		{
-		    "acKind": "ImageManifest",
-		    "acVersion": "0.7.0",
-		    "name": "` + invalidName + `"
+			desc:     "Check an empty image manifest",
+			json:     imgJ("", labsJ(), ""),
+			expected: imgI("", labsI()),
+		},
+		{
+			desc:     "Check an image manifest with an empty label",
+			json:     imgJ("example.com/test!", labsJ(labJ("", "", "")), ""),
+			expected: imgI("example.com/test!", labsI(labI("", ""))),
+		},
+		{
+			desc:     "Check an image manifest with an invalid name",
+			json:     imgJ("example.com/test!", labsJ(), ""),
+			expected: imgI("example.com/test!", labsI()),
+		},
+		{
+			desc:     "Check an image manifest with labels with invalid names",
+			json:     imgJ("im", labsJ(labJ("!n1", "v1", ""), labJ("N2~", "v2", "")), ""),
+			expected: imgI("im", labsI(labI("!n1", "v1"), labI("N2~", "v2"))),
+		},
+		{
+			desc:     "Check an image manifest with duplicated labels",
+			json:     imgJ("im", labsJ(labJ("n1", "v1", ""), labJ("n1", "v2", "")), ""),
+			expected: imgI("im", labsI(labI("n1", "v1"), labI("n1", "v2"))),
+		},
+		{
+			desc:     "Check an image manifest with some extra fields",
+			json:     imgJ("im", labsJ(), extJ("stuff")),
+			expected: imgI("im", labsI()),
+		},
+		{
+			desc:     "Check an image manifest with a label containing some extra fields",
+			json:     imgJ("im", labsJ(labJ("n1", "v1", extJ("clutter"))), extJ("stuff")),
+			expected: imgI("im", labsI(labI("n1", "v1"))),
+		},
+	}
+	for _, tt := range tests {
+		got := ImageManifest{}
+		if err := got.UnmarshalJSON([]byte(tt.json)); err != nil {
+			t.Errorf("%s: unexpected error during unmarshalling image manifest: %v", tt.desc, err)
 		}
-		`
-	if types.ValidACIdentifier.MatchString(invalidName) {
-		t.Fatalf("%q is an unexpectedly valid name", invalidName)
-	}
-	expected := ImageManifest{
-		ACKind:    "ImageManifest",
-		ACVersion: "0.7.0",
-		Name:      invalidName,
-	}
-	im := ImageManifest{}
-	if err := im.UnmarshalJSON([]byte(imj)); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if !reflect.DeepEqual(im, expected) {
-		t.Errorf("did not get expected image manifest, got: %+v, expected: %+v", im, expected)
+		if !reflect.DeepEqual(tt.expected, got) {
+			t.Errorf("%s: did not get expected image manifest, got:\n  %#v\nexpected:\n  %#v", tt.desc, got, tt.expected)
+		}
 	}
 }
 
@@ -66,5 +92,27 @@ func TestBogusImageManifest(t *testing.T) {
 		if im.UnmarshalJSON([]byte(str)) == nil {
 			t.Errorf("bogus image manifest unmarshalled successfully: %s", str)
 		}
+	}
+}
+
+// imgJ returns an image manifest JSON with given name and labels
+func imgJ(name, labels, extra string) string {
+	return fmt.Sprintf(`
+		{
+		    %s
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.7.0",
+		    "name": "%s",
+		    "labels": %s
+		}`, extra, name, labels)
+}
+
+// imgI returns an image manifest instance with given name and labels
+func imgI(name string, labels Labels) ImageManifest {
+	return ImageManifest{
+		ACVersion: "0.7.0",
+		ACKind:    "ImageManifest",
+		Name:      name,
+		Labels:    labels,
 	}
 }

--- a/schema/lastditch/labels.go
+++ b/schema/lastditch/labels.go
@@ -1,0 +1,38 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"encoding/json"
+)
+
+type Labels []Label
+
+// a type just to avoid a recursion during unmarshalling
+type labels Labels
+
+type Label struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func (l *Labels) UnmarshalJSON(data []byte) error {
+	var jl labels
+	if err := json.Unmarshal(data, &jl); err != nil {
+		return err
+	}
+	*l = Labels(jl)
+	return nil
+}

--- a/schema/lastditch/pod.go
+++ b/schema/lastditch/pod.go
@@ -35,8 +35,9 @@ type RuntimeApp struct {
 }
 
 type RuntimeImage struct {
-	Name string `json:"name"`
-	ID   string `json:"id"`
+	Name   string `json:"name"`
+	ID     string `json:"id"`
+	Labels Labels `json:"labels,omitempty"`
 }
 
 // a type just to avoid a recursion during unmarshalling

--- a/schema/lastditch/pod.go
+++ b/schema/lastditch/pod.go
@@ -30,11 +30,11 @@ type PodManifest struct {
 type AppList []RuntimeApp
 
 type RuntimeApp struct {
-	Name  string `json:"name"`
-	Image Image  `json:"image"`
+	Name  string       `json:"name"`
+	Image RuntimeImage `json:"image"`
 }
 
-type Image struct {
+type RuntimeImage struct {
 	Name string `json:"name"`
 	ID   string `json:"id"`
 }

--- a/schema/lastditch/pod_test.go
+++ b/schema/lastditch/pod_test.go
@@ -24,7 +24,7 @@ func TestInvalidPodManifest(t *testing.T) {
 	// empty image JSON
 	eImgJ := "{}"
 	// empty image instance
-	eImgI := imgI("", "")
+	eImgI := rImgI("", "")
 	tests := []struct {
 		desc     string
 		json     string
@@ -47,8 +47,8 @@ func TestInvalidPodManifest(t *testing.T) {
 		},
 		{
 			desc:     "Check a pod manifest with an invalid image name and ID",
-			json:     podJ(appJ("?", imgJ("!!!", "&&&", ""), ""), ""),
-			expected: podI(appI("?", imgI("!!!", "&&&"))),
+			json:     podJ(appJ("?", rImgJ("!!!", "&&&", ""), ""), ""),
+			expected: podI(appI("?", rImgI("!!!", "&&&"))),
 		},
 		{
 			desc:     "Check if we ignore extra fields in a pod",
@@ -62,8 +62,8 @@ func TestInvalidPodManifest(t *testing.T) {
 		},
 		{
 			desc:     "Check if we ignore extra fields in an image",
-			json:     podJ(appJ("a", imgJ("i", "id", `"labels": [],`), `"mounts": [],`), `"ports": [],`),
-			expected: podI(appI("a", imgI("i", "id"))),
+			json:     podJ(appJ("a", rImgJ("i", "id", `"labels": [],`), `"mounts": [],`), `"ports": [],`),
+			expected: podI(appI("a", rImgI("i", "id"))),
 		},
 	}
 	for _, tt := range tests {
@@ -135,15 +135,15 @@ func appJ(name, image, extra string) string {
 }
 
 // appI returns an app instance with given name and image
-func appI(name string, image Image) RuntimeApp {
+func appI(name string, image RuntimeImage) RuntimeApp {
 	return RuntimeApp{
 		Name:  name,
 		Image: image,
 	}
 }
 
-// imgJ returns an image JSON snippet with given name and id
-func imgJ(name, id, extra string) string {
+// rImgJ returns a runtime image JSON snippet with given name and id
+func rImgJ(name, id, extra string) string {
 	return fmt.Sprintf(`
 		{
 		    %s
@@ -152,9 +152,9 @@ func imgJ(name, id, extra string) string {
 		}`, extra, name, id)
 }
 
-// imgI returns an image instance with given name and id
-func imgI(name, id string) Image {
-	return Image{
+// rImgI returns a runtime image instance with given name and id
+func rImgI(name, id string) RuntimeImage {
+	return RuntimeImage{
 		Name: name,
 		ID:   id,
 	}


### PR DESCRIPTION
This PR does some cleanups first and then adds labels to pod's runtime image and to image manifest.

This may be useful for rkt to extract the version of an image (and maybe arch and os if there is need) in error cases.