### PR TITLE
aci build: add a callback to BuildWalker

### DIFF
--- a/aci/build.go
+++ b/aci/build.go
@@ -23,10 +23,18 @@ import (
 	"github.com/appc/spec/pkg/tarheader"
 )
 
+// TarHeaderWalkFunc is the type of the function which allows setting tar
+// headers or filtering out tar entries when building an ACI. It will be
+// applied to every entry in the tar file.
+//
+// If true is returned, the entry will be included in the final ACI; if false,
+// the entry will not be included.
+type TarHeaderWalkFunc func(hdr *tar.Header) bool
+
 // BuildWalker creates a filepath.WalkFunc that walks over the given root
 // (which should represent an ACI layout on disk) and adds the files in the
 // rootfs/ subdirectory to the given ArchiveWriter
-func BuildWalker(root string, aw ArchiveWriter) filepath.WalkFunc {
+func BuildWalker(root string, aw ArchiveWriter, cb TarHeaderWalkFunc) filepath.WalkFunc {
 	// cache of inode -> filepath, used to leverage hard links in the archive
 	inos := map[uint64]string{}
 	return func(path string, info os.FileInfo, err error) error {
@@ -86,6 +94,13 @@ func BuildWalker(root string, aw ArchiveWriter) filepath.WalkFunc {
 			hdr.Size = 0
 			r = nil
 		}
+
+		if cb != nil {
+			if !cb(hdr) {
+				return nil
+			}
+		}
+
 		if err := aw.AddFile(hdr, r); err != nil {
 			return err
 		}

--- a/actool/build.go
+++ b/actool/build.go
@@ -29,6 +29,7 @@ import (
 var (
 	buildNocompress bool
 	buildOverwrite  bool
+	buildOwnerRoot  bool
 	cmdBuild        = &Command{
 		Name: "build",
 		Description: `Build an ACI from a given directory. The directory should
@@ -36,13 +37,14 @@ contain an Image Layout. The Image Layout will be validated
 before the ACI is created. The produced ACI will be
 gzip-compressed by default.`,
 		Summary: "Build an ACI from an Image Layout (experimental)",
-		Usage:   `[--overwrite] [--no-compression] DIRECTORY OUTPUT_FILE`,
+		Usage:   `[--overwrite] [--no-compression] [--owner-root] DIRECTORY OUTPUT_FILE`,
 		Run:     runBuild,
 	}
 )
 
 func init() {
 	cmdBuild.Flags.BoolVar(&buildOverwrite, "overwrite", false, "Overwrite target file if it already exists")
+	cmdBuild.Flags.BoolVar(&buildOwnerRoot, "owner-root", false, "Force ownership to root:root on all files")
 	cmdBuild.Flags.BoolVar(&buildNocompress, "no-compression", false, "Do not gzip-compress the produced ACI")
 }
 
@@ -118,7 +120,16 @@ func runBuild(args []string) (exit int) {
 	}
 	iw := aci.NewImageWriter(im, tr)
 
-	err = filepath.Walk(root, aci.BuildWalker(root, iw))
+	var walkerCb aci.TarHeaderWalkFunc
+	if buildOwnerRoot {
+		walkerCb = func(hdr *tar.Header) bool {
+			hdr.Uid, hdr.Gid = 0, 0
+			hdr.Uname, hdr.Gname = "root", "root"
+			return true
+		}
+	}
+
+	err = filepath.Walk(root, aci.BuildWalker(root, iw, walkerCb))
 	if err != nil {
 		stderr("build: Error walking rootfs: %v", err)
 		return 1


### PR DESCRIPTION
This callback allows users to modify the final tar headers or filter out
tar entries when building an ACI.

Also, add a --owner-root flag to acbuild so users can adjust the uids
and gids of all the files and directories in stage1 to 0:0. This is
needed by rkt: https://github.com/coreos/rkt/issues/1453

Fixes #498