### PR TITLE
discovery: URL-encode label values

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -182,9 +182,8 @@ func DiscoverWalk(app App, insecure bool, discoverFn DiscoverWalkFunc) (err erro
 		pre := strings.Join(parts[:end], "/")
 
 		eps, err = doDiscover(pre, app, insecure)
-		derr := discoverFn(pre, eps, err)
-		if derr != nil {
-			return err
+		if derr := discoverFn(pre, eps, err); derr != nil {
+			return derr
 		}
 	}
 

--- a/discovery/parse.go
+++ b/discovery/parse.go
@@ -57,7 +57,15 @@ func NewAppFromString(app string) (*App, error) {
 		labels map[types.ACIdentifier]string
 	)
 
-	app = strings.Replace(app, ":", ",version=", -1)
+	firstComma := strings.IndexRune(app, ',')
+	firstColon := strings.IndexRune(app, ':')
+	if firstColon > firstComma && firstComma > -1 {
+		return nil, fmt.Errorf("malformed app string - colon may appear only right after the app name")
+	}
+	app = strings.Replace(app, ":", ",version=", 1)
+	if strings.ContainsRune(app, ':') {
+		return nil, fmt.Errorf("malformed app string - colon may appear at most once")
+	}
 	app = "name=" + app
 	parts := strings.Split(app, ",")
 	escapedParts := make([]string, 0, len(parts))

--- a/discovery/parse_test.go
+++ b/discovery/parse_test.go
@@ -90,6 +90,28 @@ func TestNewAppFromString(t *testing.T) {
 			nil,
 			true,
 		},
+		// colon coming after some label instead of being
+		// right after the name
+		{
+			"example.com/app,channel=beta:1.2.3",
+
+			nil,
+			true,
+		},
+		// two colons in string
+		{
+			"example.com/app:3.2.1,channel=beta:1.2.3",
+
+			nil,
+			true,
+		},
+		// two version labels, one implicit, one explicit
+		{
+			"example.com/app:3.2.1,version=1.2.3",
+
+			nil,
+			true,
+		},
 	}
 	for i, tt := range tests {
 		g, err := NewAppFromString(tt.in)

--- a/discovery/parse_test.go
+++ b/discovery/parse_test.go
@@ -52,6 +52,20 @@ func TestNewAppFromString(t *testing.T) {
 
 			false,
 		},
+		{
+			"example.com/app:1.2.3,special=!*'();@&+$/?#[],channel=beta",
+
+			&App{
+				Name: "example.com/app",
+				Labels: map[types.ACIdentifier]string{
+					"version": "1.2.3",
+					"special": "!*'();@&+$/?#[]",
+					"channel": "beta",
+				},
+			},
+
+			false,
+		},
 
 		// bad AC name for app
 		{


### PR DESCRIPTION
Appc label values can be arbitrary strings, so they might need to be
escaped to become a valid URL label.

The problem arose when the "version" label has a value like
"0.8.1+git734734", where the "+" is a reserved char as noted in RFC
3986, section 2.2.