### PR TITLE
schema/types: escape values when parsing

### DIFF
--- a/discovery/parse.go
+++ b/discovery/parse.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/appc/spec/schema/common"
 	"github.com/appc/spec/schema/types"
 )
 
@@ -93,7 +94,7 @@ func prepareAppString(app string) (string, error) {
 	}
 
 	app = "name=" + strings.Replace(app, ":", ",version=", 1)
-	return makeQueryString(app)
+	return common.MakeQueryString(app)
 }
 
 func checkColon(app string) error {
@@ -106,19 +107,6 @@ func checkColon(app string) error {
 		return fmt.Errorf("malformed app string - colon may appear at most once")
 	}
 	return nil
-}
-
-func makeQueryString(app string) (string, error) {
-	parts := strings.Split(app, ",")
-	escapedParts := make([]string, len(parts))
-	for i, s := range parts {
-		p := strings.SplitN(s, "=", 2)
-		if len(p) != 2 {
-			return "", fmt.Errorf("malformed app string - has a label without a value: %s", p[0])
-		}
-		escapedParts[i] = fmt.Sprintf("%s=%s", p[0], url.QueryEscape(p[1]))
-	}
-	return strings.Join(escapedParts, "&"), nil
 }
 
 func (a *App) Copy() *App {

--- a/schema/common/common.go
+++ b/schema/common/common.go
@@ -1,0 +1,40 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// MakeQueryString takes a comma-separated LABEL=VALUE string and returns an
+// "&"-separated string with URL escaped values.
+//
+// Examples:
+// 	version=1.0.0,label=v1+v2 -> version=1.0.0&label=v1%2Bv2
+// 	name=db,source=/tmp$1 -> name=db&source=%2Ftmp%241
+func MakeQueryString(app string) (string, error) {
+	parts := strings.Split(app, ",")
+	escapedParts := make([]string, len(parts))
+	for i, s := range parts {
+		p := strings.SplitN(s, "=", 2)
+		if len(p) != 2 {
+			return "", fmt.Errorf("malformed string %q - has a label without a value: %s", app, p[0])
+		}
+		escapedParts[i] = fmt.Sprintf("%s=%s", p[0], url.QueryEscape(p[1]))
+	}
+	return strings.Join(escapedParts, "&"), nil
+}

--- a/schema/common/common_test.go
+++ b/schema/common/common_test.go
@@ -1,0 +1,79 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+)
+
+func TestMakeQueryString(t *testing.T) {
+	tests := []struct {
+		input  string
+		output string
+		werr   bool
+	}{
+		{
+			input:  "",
+			output: "",
+			werr:   true,
+		},
+		{
+			input:  "version,label=v1+v2",
+			output: "",
+			werr:   true,
+		},
+		{
+			input:  "foo=bar",
+			output: "foo=bar",
+			werr:   false,
+		},
+		{
+			input:  "foo=bar,boo=baz",
+			output: "foo=bar&boo=baz",
+			werr:   false,
+		},
+		{
+			input:  "foo=Ümlaut",
+			output: "foo=%C3%9Cmlaut",
+			werr:   false,
+		},
+		{
+			input:  "version=1.0.0,label=v1+v2",
+			output: "version=1.0.0&label=v1%2Bv2",
+			werr:   false,
+		},
+		{
+			input:  "name=db,source=/tmp$1",
+			output: "name=db&source=%2Ftmp%241",
+			werr:   false,
+		},
+		{
+			input:  "greeting-fr=Ça va?,greeting-es=¿Cómo estás?",
+			output: "greeting-fr=%C3%87a+va%3F&greeting-es=%C2%BFC%C3%B3mo+est%C3%A1s%3F",
+			werr:   false,
+		},
+	}
+
+	for i, tt := range tests {
+		o, err := MakeQueryString(tt.input)
+		gerr := (err != nil)
+		if o != tt.output {
+			t.Errorf("#%d: expected `%v` got `%v`", i, tt.output, o)
+		}
+		if gerr != tt.werr {
+			t.Errorf("#%d: gerr=%t, want %t (err=%v)", i, gerr, tt.werr, err)
+		}
+	}
+}

--- a/schema/types/mountpoint.go
+++ b/schema/types/mountpoint.go
@@ -19,7 +19,8 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-	"strings"
+
+	"github.com/appc/spec/schema/common"
 )
 
 type MountPoint struct {
@@ -48,7 +49,12 @@ func MountPointFromString(mp string) (*MountPoint, error) {
 	var mount MountPoint
 
 	mp = "name=" + mp
-	v, err := url.ParseQuery(strings.Replace(mp, ",", "&", -1))
+	mpQuery, err := common.MakeQueryString(mp)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := url.ParseQuery(mpQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/schema/types/port.go
+++ b/schema/types/port.go
@@ -20,7 +20,8 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-	"strings"
+
+	"github.com/appc/spec/schema/common"
 )
 
 type Port struct {
@@ -84,7 +85,12 @@ func PortFromString(pt string) (*Port, error) {
 	var port Port
 
 	pt = "name=" + pt
-	v, err := url.ParseQuery(strings.Replace(pt, ",", "&", -1))
+	ptQuery, err := common.MakeQueryString(pt)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := url.ParseQuery(ptQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/schema/types/volume.go
+++ b/schema/types/volume.go
@@ -21,7 +21,8 @@ import (
 	"net/url"
 	"path/filepath"
 	"strconv"
-	"strings"
+
+	"github.com/appc/spec/schema/common"
 )
 
 // Volume encapsulates a volume which should be mounted into the filesystem
@@ -98,7 +99,12 @@ func VolumeFromString(vp string) (*Volume, error) {
 	var vol Volume
 
 	vp = "name=" + vp
-	v, err := url.ParseQuery(strings.Replace(vp, ",", "&", -1))
+	vpQuery, err := common.MakeQueryString(vp)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := url.ParseQuery(vpQuery)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To allow values with URL special characters like "+" or "&".

Fixes #465 

cc @krnowak 