### PR TITLE
discovery: add per-host HTTP headers to discovery functions

### DIFF
--- a/actool/discover.go
+++ b/actool/discover.go
@@ -54,7 +54,7 @@ func runDiscover(args []string) (exit int) {
 			stderr("%s: %s", name, err)
 			return 1
 		}
-		eps, attempts, err := discovery.DiscoverEndpoints(*app, transportFlags.Insecure)
+		eps, attempts, err := discovery.DiscoverEndpoints(*app, nil, transportFlags.Insecure)
 		if err != nil {
 			stderr("error fetching %s: %s", name, err)
 			return 1

--- a/discovery/http.go
+++ b/discovery/http.go
@@ -31,15 +31,15 @@ var (
 	// Client is the default http.Client used for discovery requests.
 	Client *http.Client
 
-	// httpGet is the internal object used by discovery to retrieve URLs; it is
+	// httpDo is the internal object used by discovery to retrieve URLs; it is
 	// defined here so it can be overridden for testing
-	httpGet httpGetter
+	httpDo httpDoer
 )
 
-// httpGetter is an interface used to wrap http.Client for real requests and
+// httpDoer is an interface used to wrap http.Client for real requests and
 // allow easy mocking in local tests.
-type httpGetter interface {
-	Get(url string) (resp *http.Response, err error)
+type httpDoer interface {
+	Do(req *http.Request) (resp *http.Response, err error)
 }
 
 func init() {
@@ -52,10 +52,10 @@ func init() {
 	Client = &http.Client{
 		Transport: t,
 	}
-	httpGet = Client
+	httpDo = Client
 }
 
-func httpsOrHTTP(name string, insecure bool) (urlStr string, body io.ReadCloser, err error) {
+func httpsOrHTTP(name string, hostHeaders map[string]http.Header, insecure bool) (urlStr string, body io.ReadCloser, err error) {
 	fetch := func(scheme string) (urlStr string, res *http.Response, err error) {
 		u, err := url.Parse(scheme + "://" + name)
 		if err != nil {
@@ -63,7 +63,14 @@ func httpsOrHTTP(name string, insecure bool) (urlStr string, body io.ReadCloser,
 		}
 		u.RawQuery = "ac-discovery=1"
 		urlStr = u.String()
-		res, err = httpGet.Get(urlStr)
+		req, err := http.NewRequest("GET", urlStr, nil)
+		if err != nil {
+			return "", nil, err
+		}
+		if hostHeader, ok := hostHeaders[u.Host]; ok {
+			req.Header = hostHeader
+		}
+		res, err = httpDo.Do(req)
 		return
 	}
 	closeBody := func(res *http.Response) {


### PR DESCRIPTION
The discovery library doesn't have support for passing auth credentials so it will fail in servers that have authentication enabled.

This PR modifies the discovery functions to accept a map with per-host headers. If the host in the discovery URL is specified in this parameter, the corresponding headers will be applied when doing the discovery.

As an alternative, we could change the parameter to be just a header and leave converting the app to a hostname and selecting the right header to the library caller.

This is not ready for review/merge, I just want to get some feedback on the general idea.

Related: https://github.com/coreos/rkt/issues/1516