### PR TITLE
schema/types: add mode, uid and gid for empty volumes

### DIFF
--- a/examples/pod_runtime.json
+++ b/examples/pod_runtime.json
@@ -88,7 +88,10 @@
         },
         {
             "name": "buildoutput",
-            "kind": "empty"
+            "kind": "empty",
+            "mode": "0777",
+            "uid": 0,
+            "gid": 0
         }
     ],
     "isolators": [

--- a/schema/types/volume_test.go
+++ b/schema/types/volume_test.go
@@ -33,6 +33,9 @@ func TestVolumeFromString(t *testing.T) {
 				Kind:     "host",
 				Source:   "/tmp",
 				ReadOnly: nil,
+				Mode:     "",
+				UID:      -1,
+				GID:      -1,
 			},
 		},
 		{
@@ -42,6 +45,9 @@ func TestVolumeFromString(t *testing.T) {
 				Kind:     "host",
 				Source:   "/tmp",
 				ReadOnly: &falseVar,
+				Mode:     "",
+				UID:      -1,
+				GID:      -1,
 			},
 		},
 		{
@@ -51,6 +57,9 @@ func TestVolumeFromString(t *testing.T) {
 				Kind:     "host",
 				Source:   "/tmp",
 				ReadOnly: &trueVar,
+				Mode:     "",
+				UID:      -1,
+				GID:      -1,
 			},
 		},
 		{
@@ -59,6 +68,9 @@ func TestVolumeFromString(t *testing.T) {
 				Name:     "foobar",
 				Kind:     "empty",
 				ReadOnly: nil,
+				Mode:     "0755",
+				UID:      0,
+				GID:      0,
 			},
 		},
 		{
@@ -67,6 +79,42 @@ func TestVolumeFromString(t *testing.T) {
 				Name:     "foobar",
 				Kind:     "empty",
 				ReadOnly: &trueVar,
+				Mode:     "0755",
+				UID:      0,
+				GID:      0,
+			},
+		},
+		{
+			"foobar,kind=empty,readOnly=true,mode=0777",
+			Volume{
+				Name:     "foobar",
+				Kind:     "empty",
+				ReadOnly: &trueVar,
+				Mode:     "0777",
+				UID:      0,
+				GID:      0,
+			},
+		},
+		{
+			"foobar,kind=empty,mode=0777,uid=1000",
+			Volume{
+				Name:     "foobar",
+				Kind:     "empty",
+				ReadOnly: nil,
+				Mode:     "0777",
+				UID:      1000,
+				GID:      0,
+			},
+		},
+		{
+			"foobar,kind=empty,mode=0777,uid=1000,gid=1000",
+			Volume{
+				Name:     "foobar",
+				Kind:     "empty",
+				ReadOnly: nil,
+				Mode:     "0777",
+				UID:      1000,
+				GID:      1000,
 			},
 		},
 	}

--- a/spec/pods.md
+++ b/spec/pods.md
@@ -174,6 +174,9 @@ JSON Schema for the Pod Manifest, conforming to [RFC4627](https://tools.ietf.org
         * **empty** - creates an empty directory on the host and bind mounts it into the container. All containers in the pod share the mount, and the lifetime of the volume is equal to the lifetime of the pod (i.e. the directory on the host machine is removed when the pod's filesystem is garbage collected)
         * **host** - fulfills a mount point with a bind mount from a **source** directory on the host.
     * **source** (string, required if **kind** is "host") absolute path on host to be bind mounted under a mount point in each app's chroot.
+    * **mode** (integer, optional, only interpreted if **kind** is "empty", defaults to "0755" if unsupplied) indicates the mode permission of the empty volume.
+    * **uid** (integer, optional, only interpreted if **kind** is "empty", defaults to "0" if unsupplied) indicates the user id that will own the empty volume. Note it is an integer number because each app in the pod would interpret a user name differently.
+    * **gid** (integer, optional, only interpreted if **kind** is "empty", defaults to "0" if unsupplied) indicates the group id that will own the empty volume. Note it is an integer number because each app in the pod would interpret a group name differently.
 * **isolators** (list of objects of type [Isolator](types.md#isolator-type), optional) list of isolation steps that will apply to this pod.
 * **annotations** (list of objects, optional) arbitrary metadata the executor will make available to applications via the metadata service. Objects must contain two key-value pairs: **name** is restricted to the [AC Name](types.md#ac-name-type) formatting and **value** is an arbitrary string). Annotation names must be unique within the list.
 * **ports** (list of objects, optional) list of ports that SHOULD be exposed on the host.


### PR DESCRIPTION
This allows setting which UID and GID and permission mode will be
applied to an empty volume.

We only allow UIDs and GIDs because a user/group name wouldn't make
sense in the Pod context: each app in the Pod can have a different
/etc/passwd with different mappings.

Fixes #526 