### PR TITLE
schema: add better manifest parsing errors

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -6,6 +6,10 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/camlistore/camlistore/pkg/errorutil",
+			"Rev": "9106ce829629773474c689b34aacd7d3aaa99426"
+		},
+		{
 			"ImportPath": "github.com/coreos/go-semver/semver",
 			"Rev": "6fe83ccda8fb9b7549c9ab4ba47f47858bc950aa"
 		},

--- a/Godeps/_workspace/src/github.com/camlistore/camlistore/pkg/errorutil/highlight.go
+++ b/Godeps/_workspace/src/github.com/camlistore/camlistore/pkg/errorutil/highlight.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2011 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package errorutil helps make better error messages.
+package errorutil
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// HighlightBytePosition takes a reader and the location in bytes of a parse
+// error (for instance, from json.SyntaxError.Offset) and returns the line, column,
+// and pretty-printed context around the error with an arrow indicating the exact
+// position of the syntax error.
+func HighlightBytePosition(f io.Reader, pos int64) (line, col int, highlight string) {
+	line = 1
+	br := bufio.NewReader(f)
+	lastLine := ""
+	thisLine := new(bytes.Buffer)
+	for n := int64(0); n < pos; n++ {
+		b, err := br.ReadByte()
+		if err != nil {
+			break
+		}
+		if b == '\n' {
+			lastLine = thisLine.String()
+			thisLine.Reset()
+			line++
+			col = 1
+		} else {
+			col++
+			thisLine.WriteByte(b)
+		}
+	}
+	if line > 1 {
+		highlight += fmt.Sprintf("%5d: %s\n", line-1, lastLine)
+	}
+	highlight += fmt.Sprintf("%5d: %s\n", line, thisLine.String())
+	highlight += fmt.Sprintf("%s^\n", strings.Repeat(" ", col+5))
+	return
+}

--- a/schema/image.go
+++ b/schema/image.go
@@ -15,10 +15,14 @@
 package schema
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/appc/spec/schema/types"
+
+	"github.com/appc/spec/Godeps/_workspace/src/github.com/camlistore/camlistore/pkg/errorutil"
 )
 
 const (
@@ -49,6 +53,10 @@ func (im *ImageManifest) UnmarshalJSON(data []byte) error {
 	a := imageManifest(*im)
 	err := json.Unmarshal(data, &a)
 	if err != nil {
+		if serr, ok := err.(*json.SyntaxError); ok {
+			line, col, highlight := errorutil.HighlightBytePosition(bytes.NewReader(data), serr.Offset)
+			return fmt.Errorf("\nError at line %d, column %d\n%s%v", line, col, highlight, err)
+		}
 		return err
 	}
 	nim := ImageManifest(a)

--- a/schema/pod.go
+++ b/schema/pod.go
@@ -15,11 +15,14 @@
 package schema
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 
 	"github.com/appc/spec/schema/types"
+
+	"github.com/appc/spec/Godeps/_workspace/src/github.com/camlistore/camlistore/pkg/errorutil"
 )
 
 const PodManifestKind = types.ACKind("PodManifest")
@@ -46,6 +49,10 @@ func (pm *PodManifest) UnmarshalJSON(data []byte) error {
 	p := podManifest(*pm)
 	err := json.Unmarshal(data, &p)
 	if err != nil {
+		if serr, ok := err.(*json.SyntaxError); ok {
+			line, col, highlight := errorutil.HighlightBytePosition(bytes.NewReader(data), serr.Offset)
+			return fmt.Errorf("\nError at line %d, column %d\n%s%v", line, col, highlight, err)
+		}
 		return err
 	}
 	npm := PodManifest(p)


### PR DESCRIPTION
With line and column numbers, and a highlight string.

Example:

```
Error at line 13, column 8
   12:       }
   13:       {
             ^
invalid character '{' after array element
```