### PR TITLE
schema/types: rework empty volume type code

### DIFF
--- a/schema/types/volume.go
+++ b/schema/types/volume.go
@@ -25,6 +25,12 @@ import (
 	"github.com/appc/spec/schema/common"
 )
 
+const (
+	emptyVolumeDefaultMode = "0755"
+	emptyVolumeDefaultUID  = 0
+	emptyVolumeDefaultGID  = 0
+)
+
 // Volume encapsulates a volume which should be mounted into the filesystem
 // of all apps in a PodManifest
 type Volume struct {
@@ -37,9 +43,9 @@ type Volume struct {
 	ReadOnly *bool  `json:"readOnly,omitempty"`
 
 	// currently used only by "empty"
-	Mode string `json:"mode,omitempty"`
-	UID  int    `json:"uid,omitempty"`
-	GID  int    `json:"gid,omitempty"`
+	Mode *string `json:"mode,omitempty"`
+	UID  *int    `json:"uid,omitempty"`
+	GID  *int    `json:"gid,omitempty"`
 }
 
 type volume Volume
@@ -54,19 +60,28 @@ func (v Volume) assertValid() error {
 		if v.Source != "" {
 			return errors.New("source for empty volume must be empty")
 		}
-		if v.Mode == "" {
+		if v.Mode == nil {
 			return errors.New("mode for empty volume must be set")
 		}
-		if v.UID == -1 {
+		if v.UID == nil {
 			return errors.New("uid for empty volume must be set")
 		}
-		if v.GID == -1 {
+		if v.GID == nil {
 			return errors.New("gid for empty volume must be set")
 		}
 		return nil
 	case "host":
 		if v.Source == "" {
 			return errors.New("source for host volume cannot be empty")
+		}
+		if v.Mode != nil {
+			return errors.New("mode for host volume cannot be set")
+		}
+		if v.UID != nil {
+			return errors.New("uid for host volume cannot be set")
+		}
+		if v.GID != nil {
+			return errors.New("gid for host volume cannot be set")
 		}
 		if !filepath.IsAbs(v.Source) {
 			return errors.New("source for host volume must be absolute path")
@@ -79,20 +94,13 @@ func (v Volume) assertValid() error {
 
 func (v *Volume) UnmarshalJSON(data []byte) error {
 	var vv volume
-	vv.Mode = "0755"
-	vv.UID = 0
-	vv.GID = 0
 	if err := json.Unmarshal(data, &vv); err != nil {
 		return err
 	}
 	nv := Volume(vv)
+	maybeSetDefaults(&nv)
 	if err := nv.assertValid(); err != nil {
 		return err
-	}
-	if nv.Kind != "empty" {
-		nv.Mode = ""
-		nv.UID = -1
-		nv.GID = -1
 	}
 	*v = nv
 	return nil
@@ -106,12 +114,24 @@ func (v Volume) MarshalJSON() ([]byte, error) {
 }
 
 func (v Volume) String() string {
-	s := fmt.Sprintf("%s,kind=%s,readOnly=%t", v.Name, v.Kind, *v.ReadOnly)
+	s := fmt.Sprintf("%s,kind=%s", v.Name, v.Kind)
 	if v.Source != "" {
-		s = s + fmt.Sprintf(",source=%s", v.Source)
+		s += fmt.Sprintf(",source=%s", v.Source)
 	}
-	if v.Mode != "" && v.UID != -1 && v.GID != -1 {
-		s = s + fmt.Sprintf(",mode=%s,uid=%d,gid=%d", v.Mode, v.UID, v.GID)
+	if v.ReadOnly != nil {
+		s += fmt.Sprintf(",readOnly=%t", *v.ReadOnly)
+	}
+	switch v.Kind {
+	case "empty":
+		if *v.Mode != emptyVolumeDefaultMode {
+			s += fmt.Sprintf(",mode=%s", *v.Mode)
+		}
+		if *v.UID != emptyVolumeDefaultUID {
+			s += fmt.Sprintf(",uid=%d", *v.UID)
+		}
+		if *v.GID != emptyVolumeDefaultGID {
+			s += fmt.Sprintf(",gid=%d", *v.GID)
+		}
 	}
 	return s
 }
@@ -121,11 +141,7 @@ func (v Volume) String() string {
 // Example volume parameters:
 // 	database,kind=host,source=/tmp,readOnly=true
 func VolumeFromString(vp string) (*Volume, error) {
-	vol := Volume{
-		Mode: "0755",
-		UID:  0,
-		GID:  0,
-	}
+	var vol Volume
 
 	vp = "name=" + vp
 	vpQuery, err := common.MakeQueryString(vp)
@@ -138,6 +154,7 @@ func VolumeFromString(vp string) (*Volume, error) {
 		return nil, err
 	}
 	for key, val := range v {
+		val := val
 		if len(val) > 1 {
 			return nil, fmt.Errorf("label %s with multiple values %q", key, val)
 		}
@@ -160,32 +177,50 @@ func VolumeFromString(vp string) (*Volume, error) {
 			}
 			vol.ReadOnly = &ro
 		case "mode":
-			vol.Mode = val[0]
+			vol.Mode = &val[0]
 		case "uid":
 			u, err := strconv.Atoi(val[0])
 			if err != nil {
 				return nil, err
 			}
-			vol.UID = u
+			vol.UID = &u
 		case "gid":
 			g, err := strconv.Atoi(val[0])
 			if err != nil {
 				return nil, err
 			}
-			vol.GID = g
+			vol.GID = &g
 		default:
 			return nil, fmt.Errorf("unknown volume parameter %q", key)
 		}
 	}
+
+	maybeSetDefaults(&vol)
+
 	err = vol.assertValid()
 	if err != nil {
 		return nil, err
 	}
-	if vol.Kind != "empty" {
-		vol.Mode = ""
-		vol.UID = -1
-		vol.GID = -1
-	}
 
 	return &vol, nil
+}
+
+// maybeSetDefaults sets the correct default values for certain fields on a
+// Volume if they are not already been set. These fields are not
+// pre-populated on all Volumes as the Volume type is polymorphic.
+func maybeSetDefaults(vol *Volume) {
+	if vol.Kind == "empty" {
+		if vol.Mode == nil {
+			m := emptyVolumeDefaultMode
+			vol.Mode = &m
+		}
+		if vol.UID == nil {
+			u := emptyVolumeDefaultUID
+			vol.UID = &u
+		}
+		if vol.GID == nil {
+			g := emptyVolumeDefaultGID
+			vol.GID = &g
+		}
+	}
 }

--- a/schema/types/volume.go
+++ b/schema/types/volume.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/appc/spec/schema/common"
 )
@@ -114,26 +115,35 @@ func (v Volume) MarshalJSON() ([]byte, error) {
 }
 
 func (v Volume) String() string {
-	s := fmt.Sprintf("%s,kind=%s", v.Name, v.Kind)
+	s := []string{
+		v.Name.String(),
+		",kind=",
+		v.Kind,
+	}
 	if v.Source != "" {
-		s += fmt.Sprintf(",source=%s", v.Source)
+		s = append(s, ",source=")
+		s = append(s, v.Source)
 	}
 	if v.ReadOnly != nil {
-		s += fmt.Sprintf(",readOnly=%t", *v.ReadOnly)
+		s = append(s, ",readOnly=")
+		s = append(s, strconv.FormatBool(*v.ReadOnly))
 	}
 	switch v.Kind {
 	case "empty":
 		if *v.Mode != emptyVolumeDefaultMode {
-			s += fmt.Sprintf(",mode=%s", *v.Mode)
+			s = append(s, ",mode=")
+			s = append(s, *v.Mode)
 		}
 		if *v.UID != emptyVolumeDefaultUID {
-			s += fmt.Sprintf(",uid=%d", *v.UID)
+			s = append(s, ",uid=")
+			s = append(s, strconv.Itoa(*v.UID))
 		}
 		if *v.GID != emptyVolumeDefaultGID {
-			s += fmt.Sprintf(",gid=%d", *v.GID)
+			s = append(s, ",gid=")
+			s = append(s, strconv.Itoa(*v.GID))
 		}
 	}
-	return s
+	return strings.Join(s, "")
 }
 
 // VolumeFromString takes a command line volume parameter and returns a volume

--- a/schema/types/volume_test.go
+++ b/schema/types/volume_test.go
@@ -19,7 +19,15 @@ import (
 	"testing"
 )
 
-func TestVolumeFromString(t *testing.T) {
+func sp(s string) *string {
+	return &s
+}
+
+func ip(i int) *int {
+	return &i
+}
+
+func TestVolumeToFromString(t *testing.T) {
 	trueVar := true
 	falseVar := false
 	tests := []struct {
@@ -33,9 +41,9 @@ func TestVolumeFromString(t *testing.T) {
 				Kind:     "host",
 				Source:   "/tmp",
 				ReadOnly: nil,
-				Mode:     "",
-				UID:      -1,
-				GID:      -1,
+				Mode:     nil,
+				UID:      nil,
+				GID:      nil,
 			},
 		},
 		{
@@ -45,9 +53,9 @@ func TestVolumeFromString(t *testing.T) {
 				Kind:     "host",
 				Source:   "/tmp",
 				ReadOnly: &falseVar,
-				Mode:     "",
-				UID:      -1,
-				GID:      -1,
+				Mode:     nil,
+				UID:      nil,
+				GID:      nil,
 			},
 		},
 		{
@@ -57,9 +65,9 @@ func TestVolumeFromString(t *testing.T) {
 				Kind:     "host",
 				Source:   "/tmp",
 				ReadOnly: &trueVar,
-				Mode:     "",
-				UID:      -1,
-				GID:      -1,
+				Mode:     nil,
+				UID:      nil,
+				GID:      nil,
 			},
 		},
 		{
@@ -68,9 +76,9 @@ func TestVolumeFromString(t *testing.T) {
 				Name:     "foobar",
 				Kind:     "empty",
 				ReadOnly: nil,
-				Mode:     "0755",
-				UID:      0,
-				GID:      0,
+				Mode:     sp(emptyVolumeDefaultMode),
+				UID:      ip(emptyVolumeDefaultUID),
+				GID:      ip(emptyVolumeDefaultGID),
 			},
 		},
 		{
@@ -79,9 +87,9 @@ func TestVolumeFromString(t *testing.T) {
 				Name:     "foobar",
 				Kind:     "empty",
 				ReadOnly: &trueVar,
-				Mode:     "0755",
-				UID:      0,
-				GID:      0,
+				Mode:     sp(emptyVolumeDefaultMode),
+				UID:      ip(emptyVolumeDefaultUID),
+				GID:      ip(emptyVolumeDefaultGID),
 			},
 		},
 		{
@@ -90,9 +98,9 @@ func TestVolumeFromString(t *testing.T) {
 				Name:     "foobar",
 				Kind:     "empty",
 				ReadOnly: &trueVar,
-				Mode:     "0777",
-				UID:      0,
-				GID:      0,
+				Mode:     sp("0777"),
+				UID:      ip(emptyVolumeDefaultUID),
+				GID:      ip(emptyVolumeDefaultGID),
 			},
 		},
 		{
@@ -101,9 +109,9 @@ func TestVolumeFromString(t *testing.T) {
 				Name:     "foobar",
 				Kind:     "empty",
 				ReadOnly: nil,
-				Mode:     "0777",
-				UID:      1000,
-				GID:      0,
+				Mode:     sp("0777"),
+				UID:      ip(1000),
+				GID:      ip(emptyVolumeDefaultGID),
 			},
 		},
 		{
@@ -112,9 +120,9 @@ func TestVolumeFromString(t *testing.T) {
 				Name:     "foobar",
 				Kind:     "empty",
 				ReadOnly: nil,
-				Mode:     "0777",
-				UID:      1000,
-				GID:      1000,
+				Mode:     sp("0777"),
+				UID:      ip(1000),
+				GID:      ip(1000),
 			},
 		},
 	}
@@ -126,6 +134,11 @@ func TestVolumeFromString(t *testing.T) {
 		if !reflect.DeepEqual(*v, tt.v) {
 			t.Errorf("#%d: v=%v, want %v", i, *v, tt.v)
 		}
+		// volume serialization should be reversible
+		o := v.String()
+		if o != tt.s {
+			t.Errorf("#%d: v.String()=%s, want %s", i, o, tt.s)
+		}
 	}
 }
 
@@ -133,6 +146,10 @@ func TestVolumeFromStringBad(t *testing.T) {
 	tests := []string{
 		"#foobar,kind=host,source=/tmp",
 		"foobar,kind=host,source=/tmp,readOnly=true,asdf=asdf",
+		"foobar,kind=host,source=tmp",
+		"foobar,kind=host,uid=3",
+		"foobar,kind=host,mode=0755",
+		"foobar,kind=host,mode=0600,readOnly=true,gid=0",
 		"foobar,kind=empty,source=/tmp",
 	}
 	for i, in := range tests {

--- a/schema/types/volume_test.go
+++ b/schema/types/volume_test.go
@@ -162,3 +162,18 @@ func TestVolumeFromStringBad(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkVolumeToString(b *testing.B) {
+	trueVar := true
+	vol := Volume{
+		Name:     "foobar",
+		Kind:     "empty",
+		ReadOnly: &trueVar,
+		Mode:     sp("0777"),
+		UID:      ip(3),
+		GID:      ip(4),
+	}
+	for i := 0; i < b.N; i++ {
+		_ = vol.String()
+	}
+}

--- a/schema/types/volume_test.go
+++ b/schema/types/volume_test.go
@@ -19,6 +19,10 @@ import (
 	"testing"
 )
 
+func bp(b bool) *bool {
+	return &b
+}
+
 func sp(s string) *string {
 	return &s
 }
@@ -28,8 +32,6 @@ func ip(i int) *int {
 }
 
 func TestVolumeToFromString(t *testing.T) {
-	trueVar := true
-	falseVar := false
 	tests := []struct {
 		s string
 		v Volume
@@ -52,7 +54,7 @@ func TestVolumeToFromString(t *testing.T) {
 				Name:     "foobar",
 				Kind:     "host",
 				Source:   "/tmp",
-				ReadOnly: &falseVar,
+				ReadOnly: bp(false),
 				Mode:     nil,
 				UID:      nil,
 				GID:      nil,
@@ -64,7 +66,7 @@ func TestVolumeToFromString(t *testing.T) {
 				Name:     "foobar",
 				Kind:     "host",
 				Source:   "/tmp",
-				ReadOnly: &trueVar,
+				ReadOnly: bp(true),
 				Mode:     nil,
 				UID:      nil,
 				GID:      nil,
@@ -86,7 +88,7 @@ func TestVolumeToFromString(t *testing.T) {
 			Volume{
 				Name:     "foobar",
 				Kind:     "empty",
-				ReadOnly: &trueVar,
+				ReadOnly: bp(true),
 				Mode:     sp(emptyVolumeDefaultMode),
 				UID:      ip(emptyVolumeDefaultUID),
 				GID:      ip(emptyVolumeDefaultGID),
@@ -97,7 +99,7 @@ func TestVolumeToFromString(t *testing.T) {
 			Volume{
 				Name:     "foobar",
 				Kind:     "empty",
-				ReadOnly: &trueVar,
+				ReadOnly: bp(true),
 				Mode:     sp("0777"),
 				UID:      ip(emptyVolumeDefaultUID),
 				GID:      ip(emptyVolumeDefaultGID),
@@ -164,11 +166,10 @@ func TestVolumeFromStringBad(t *testing.T) {
 }
 
 func BenchmarkVolumeToString(b *testing.B) {
-	trueVar := true
 	vol := Volume{
 		Name:     "foobar",
 		Kind:     "empty",
-		ReadOnly: &trueVar,
+		ReadOnly: bp(true),
 		Mode:     sp("0777"),
 		UID:      ip(3),
 		GID:      ip(4),


### PR DESCRIPTION
tl;dr: this patch:
- fixes a panic in the Volume type's String() method
- ensures that the serialization of a Volume to/from a string is
  reversible - i.e., `s == VolumeFromString(s).String()`

Full details:

The `Volume` type is polymorphic; it can be of several different Kinds,
and for each Kind only a select few fields are valid. When new fields
(`mode`, `uid`, `gid`) were added to the `empty` volume Kind (via
26af7cefe402259b348fdfa2299d8d2e0a595e2e), they were simply added as new
fields. However, this means that Volume structs of Kinds for which those
fields are not valid (e.g. the `host` Kind) would necessarily have
values set in those fields - since in Go any fields will be
automatically set to their zero value. To mitigate this, the previous
code set special sentinel values to those fields (e.g. -1 to the
`uid`/`mode` fields) to indicate that they were "unset"; but this is
slightly awkward since it necessitates manually setting those sentinel
values at certain points.

This patch instead change those fields to be pointers, so that it is
trivially possible to determine whether or not those fields are really
set, and disambiguate from the zeroed value case. This also means that a
"zeroed" Volume type is really unset and does not need modification to
set the sentinels appropriately.

Another change is in how exactly a Volume type is serialized to a
string. `String()` previously attempted to dereference the `readOnly`
field even if it was not necessarily set. Even though such a nil
dereference would ordinarily cause the Go runtime to panic, the
`fmt.Printf` function (and friends) uses a `recover()` to actually
_catch_ any panic occurred, so instead this results in a weird panic
trace _within the returned string_, but business otherwise continues as
usual (smdh).

As well as fixing this panic (by checking the pointer before
dereferencing), we now also construct the serialized Volume string
piece-by-piece, only if fields are set; for example, if an `empty`
Volume's `mode` field is set to the default value, we will omit it from
the serialized string.