### PR TITLE
schema/types: fix capabilities marshaling

### DIFF
--- a/schema/types/isolator_linux_specific.go
+++ b/schema/types/isolator_linux_specific.go
@@ -96,7 +96,7 @@ func NewLinuxCapabilitiesRetainSet(caps ...string) (*LinuxCapabilitiesRetainSet,
 }
 
 func (l LinuxCapabilitiesRetainSet) AsIsolator() Isolator {
-	b, err := json.Marshal(l)
+	b, err := json.Marshal(l.linuxCapabilitiesSetBase.val)
 	if err != nil {
 		panic(err)
 	}
@@ -130,7 +130,7 @@ func NewLinuxCapabilitiesRevokeSet(caps ...string) (*LinuxCapabilitiesRevokeSet,
 }
 
 func (l LinuxCapabilitiesRevokeSet) AsIsolator() Isolator {
-	b, err := json.Marshal(l)
+	b, err := json.Marshal(l.linuxCapabilitiesSetBase.val)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
appc/spec v0.7.2 broke "actool patch-manifest --capability" during the
isolator refactoring https://github.com/appc/spec/pull/517.

Fixes https://github.com/appc/spec/issues/542
