### PR TITLE
discovery: add insecureTls flag to skip TLS checks

### DIFF
--- a/actool/discover.go
+++ b/actool/discover.go
@@ -36,7 +36,7 @@ var (
 
 func init() {
 	cmdDiscover.Flags.BoolVar(&transportFlags.Insecure, "insecure", false,
-		"Allow insecure non-TLS downloads over http")
+		"Don't check TLS certificates and allow insecure non-TLS downloads over http")
 	cmdDiscover.Flags.BoolVar(&outputJson, "json", false,
 		"Output result as JSON")
 }
@@ -58,7 +58,11 @@ func runDiscover(args []string) (exit int) {
 			stderr("%s: %s", name, err)
 			return 1
 		}
-		eps, attempts, err := discovery.DiscoverEndpoints(*app, nil, transportFlags.Insecure)
+		insecure := discovery.InsecureNone
+		if transportFlags.Insecure {
+			insecure = discovery.InsecureTls | discovery.InsecureHttp
+		}
+		eps, attempts, err := discovery.DiscoverEndpoints(*app, nil, insecure)
 		if err != nil {
 			stderr("error fetching %s: %s", name, err)
 			return 1

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -124,7 +124,7 @@ func createTemplateVars(app App) []string {
 	return tplVars
 }
 
-func doDiscover(pre string, hostHeaders map[string]http.Header, app App, insecure bool) (*Endpoints, error) {
+func doDiscover(pre string, hostHeaders map[string]http.Header, app App, insecure InsecureOption) (*Endpoints, error) {
 	app = *app.Copy()
 	if app.Labels["version"] == "" {
 		app.Labels["version"] = defaultVersion
@@ -173,7 +173,7 @@ func doDiscover(pre string, hostHeaders map[string]http.Header, app App, insecur
 // optionally will use HTTP if insecure is set. hostHeaders specifies the
 // header to apply depending on the host (e.g. authentication). Based on the
 // response of the discoverFn it will continue to recurse up the tree.
-func DiscoverWalk(app App, hostHeaders map[string]http.Header, insecure bool, discoverFn DiscoverWalkFunc) (err error) {
+func DiscoverWalk(app App, hostHeaders map[string]http.Header, insecure InsecureOption, discoverFn DiscoverWalkFunc) (err error) {
 	var (
 		eps *Endpoints
 	)
@@ -221,7 +221,7 @@ func walker(out *Endpoints, attempts *[]FailedAttempt, testFn DiscoverWalkFunc) 
 // specifies the header to apply depending on the host (e.g. authentication).
 // It will not give up until it has exhausted the path or found an image
 // discovery.
-func DiscoverEndpoints(app App, hostHeaders map[string]http.Header, insecure bool) (out *Endpoints, attempts []FailedAttempt, err error) {
+func DiscoverEndpoints(app App, hostHeaders map[string]http.Header, insecure InsecureOption) (out *Endpoints, attempts []FailedAttempt, err error) {
 	out = &Endpoints{}
 	testFn := func(pre string, eps *Endpoints, err error) error {
 		if len(out.ACIEndpoints) != 0 {
@@ -242,7 +242,7 @@ func DiscoverEndpoints(app App, hostHeaders map[string]http.Header, insecure boo
 // tags and optionally will use HTTP if insecure is set. hostHeaders
 // specifies the header to apply depending on the host (e.g. authentication).
 // It will not give up until it has exhausted the path or found an public key.
-func DiscoverPublicKeys(app App, hostHeaders map[string]http.Header, insecure bool) (out *Endpoints, attempts []FailedAttempt, err error) {
+func DiscoverPublicKeys(app App, hostHeaders map[string]http.Header, insecure InsecureOption) (out *Endpoints, attempts []FailedAttempt, err error) {
 	out = &Endpoints{}
 	testFn := func(pre string, eps *Endpoints, err error) error {
 		if len(out.Keys) != 0 {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -182,7 +182,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			&mockHttpDoer{
 				doer: fakeHTTPGet("myapp2.html", 0, nil),
 			},
-			false,
+			true,
 			App{
 				Name:   "example.com/myapp",
 				Labels: map[types.ACIdentifier]string{},
@@ -201,7 +201,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			&mockHttpDoer{
 				doer: fakeHTTPGet("myapp2.html", 0, nil),
 			},
-			false,
+			true,
 			App{
 				Name: "example.com/myapp",
 				Labels: map[types.ACIdentifier]string{
@@ -266,6 +266,9 @@ func TestDiscoverEndpoints(t *testing.T) {
 			de, _, err := DiscoverEndpoints(tt.app, hostHeaders, insecure)
 			if err != nil && !tt.expectDiscoverySuccess {
 				continue
+			}
+			if err == nil && !tt.expectDiscoverySuccess {
+				t.Fatalf("#%d DiscoverEndpoints should have failed but didn't", i)
 			}
 			if err != nil {
 				t.Fatalf("#%d DiscoverEndpoints failed: %v", i, err)


### PR DESCRIPTION
The "insecure" was previously used to allow http. This is now split into
two flags "insecureHttp" and "insecureTls".

Related to https://github.com/appc/spec/issues/545

-----

/cc @krnowak 

I will need this for tests in rkt, see https://github.com/coreos/rkt/pull/1822.