### PR TITLE
spec: clarify image dependencies

### DIFF
--- a/spec/aci.md
+++ b/spec/aci.md
@@ -67,7 +67,7 @@ Image manifests MUST be valid JSON located in the file `manifest` in the root of
 Image manifests MAY specify dependencies, which describe how to assemble the final rootfs from a collection of other images.
 As an example, an app might require special certificates to be layered into its filesystem.
 In this case, the app can reference the name "example.com/trusted-certificate-authority" as a dependency in the image manifest.
-The dependencies are applied in order and each image dependency can overwrite files from the previous dependency.
+The dependencies are applied in the order defined in the [Filesystem Setup specification](ace.md#filesystem-setup) and each image dependency can overwrite files from the previous dependency.
 Execution details specified in image dependencies are ignored.
 An optional *path whitelist* can be provided, in which case all non-specified files from all dependencies will be omitted in the final, assembled rootfs.
 


### PR DESCRIPTION
Fixes https://github.com/appc/spec/issues/538

-----

The ordering explained in this PR is the ordering currently implemented. But the chain of `pathWhitelist` seems to be only partially implemented in [GetRenderedACIFromList()](https://github.com/appc/spec/blob/master/pkg/acirenderer/acirenderer.go#L100).

/cc @n0rad