### PR TITLE
Remove dependency on glibc in linux systems.

### DIFF
--- a/pkg/device/device_linux.go
+++ b/pkg/device/device_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The appc Authors
+// Copyright 2016 The appc Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,46 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build freebsd netbsd openbsd darwin
+// +build linux
 
 package device
 
-/*
-#define _BSD_SOURCE
-#define _DEFAULT_SOURCE
-#include <sys/types.h>
-
-unsigned int
-my_major(dev_t dev)
-{
-  return major(dev);
-}
-
-unsigned int
-my_minor(dev_t dev)
-{
-  return minor(dev);
-}
-
-dev_t
-my_makedev(unsigned int maj, unsigned int min)
-{
-       return makedev(maj, min);
-}
-*/
-import "C"
+// with glibc/sysdeps/unix/sysv/linux/sys/sysmacros.h as reference
 
 func Major(rdev uint64) uint {
-	major := C.my_major(C.dev_t(rdev))
-	return uint(major)
+	return uint((rdev>>8)&0xfff) | (uint(rdev>>32) & ^uint(0xfff))
 }
 
 func Minor(rdev uint64) uint {
-	minor := C.my_minor(C.dev_t(rdev))
-	return uint(minor)
+	return uint(rdev&0xff) | uint(uint32(rdev>>12) & ^uint32(0xff))
 }
 
 func Makedev(maj uint, min uint) uint64 {
-	dev := C.my_makedev(C.uint(maj), C.uint(min))
-	return uint64(dev)
+	return uint64(min&0xff) | (uint64(maj&0xfff) << 8) |
+		((uint64(min) & ^uint64(0xff)) << 12) |
+		((uint64(maj) & ^uint64(0xfff)) << 32)
 }


### PR DESCRIPTION
On linux platform - remove dependency on macros from glibc headers.
With this change - whole library can be used witouth CGO, so it can be
used to build fully statically linked binary.