### PR TITLE
ace: use actual GOOS and GOARCH when building validator ACIs

### DIFF
--- a/ace/build_aci
+++ b/ace/build_aci
@@ -6,6 +6,8 @@ set -eu
 
 PREFIX="ace"
 : ${NO_SIGNATURE=}
+GOOS="$(go env GOOS)"
+GOARCH="$(go env GOARCH)"
 
 if ! [[ $0 =~ "${PREFIX}/build_aci" ]]; then 
 	echo "invoke from repository root" 1>&2
@@ -20,7 +22,7 @@ for typ in main sidekick; do
 	layoutdir="bin/ace-${typ}-layout"
 	mkdir -p ${layoutdir}/rootfs/opt/acvalidator
 	cp bin/ace-validator ${layoutdir}/rootfs/
-	cp ${PREFIX}/image_manifest_${typ}.json ${layoutdir}/manifest
+	sed -e "s/@GOOS@/$GOOS/" -e "s/@GOARCH@/$GOARCH/" < ${PREFIX}/image_manifest_${typ}.json.in > ${layoutdir}/manifest
 	# now build the tarball, and sign it
 	pushd ${layoutdir} >/dev/null
 		# Set a consistent timestamp so we get a consistent hash

--- a/ace/image_manifest_main.json.in
+++ b/ace/image_manifest_main.json.in
@@ -4,8 +4,8 @@
     "name": "coreos.com/ace-validator-main",
     "labels": [
         { "name": "version", "value": "0.7.4" },
-        { "name": "os", "value": "linux" },
-        { "name": "arch", "value": "amd64" }
+        { "name": "os", "value": "@GOOS@" },
+        { "name": "arch", "value": "@GOARCH@" }
     ],
     "app": {
         "exec": [

--- a/ace/image_manifest_sidekick.json.in
+++ b/ace/image_manifest_sidekick.json.in
@@ -4,8 +4,8 @@
     "name": "coreos.com/ace-validator-sidekick",
     "labels": [
         { "name": "version", "value": "0.7.4" },
-        { "name": "os", "value": "linux" },
-        { "name": "arch", "value": "amd64" }
+        { "name": "os", "value": "@GOOS@" },
+        { "name": "arch", "value": "@GOARCH@" }
     ],
     "app": {
         "exec": [


### PR DESCRIPTION
Currently, `os` of built validator ACI is hardcoded to `linux`, which makes ugly patches necessary to make it run properly on Jetpack. This patch makes the build script use current `GOOS` and `GOARCH` values for the `os` and `arch` tags.