### PR TITLE
Godeps: unrewrite import paths

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/appc/spec",
-	"GoVersion": "go1.4.1",
+	"GoVersion": "go1.5",
 	"Packages": [
 		"./..."
 	],

--- a/Godeps/_workspace/src/golang.org/x/net/html/charset/charset.go
+++ b/Godeps/_workspace/src/golang.org/x/net/html/charset/charset.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/appc/spec/Godeps/_workspace/src/golang.org/x/net/html"
+	"golang.org/x/net/html"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/charmap"
 	"golang.org/x/text/transform"

--- a/Godeps/_workspace/src/golang.org/x/net/html/example_test.go
+++ b/Godeps/_workspace/src/golang.org/x/net/html/example_test.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/appc/spec/Godeps/_workspace/src/golang.org/x/net/html"
+	"golang.org/x/net/html"
 )
 
 func ExampleParse() {

--- a/Godeps/_workspace/src/golang.org/x/net/html/node.go
+++ b/Godeps/_workspace/src/golang.org/x/net/html/node.go
@@ -5,7 +5,7 @@
 package html
 
 import (
-	"github.com/appc/spec/Godeps/_workspace/src/golang.org/x/net/html/atom"
+	"golang.org/x/net/html/atom"
 )
 
 // A NodeType is the type of a Node.

--- a/Godeps/_workspace/src/golang.org/x/net/html/parse.go
+++ b/Godeps/_workspace/src/golang.org/x/net/html/parse.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"strings"
 
-	a "github.com/appc/spec/Godeps/_workspace/src/golang.org/x/net/html/atom"
+	a "golang.org/x/net/html/atom"
 )
 
 // A parser implements the HTML5 parsing algorithm:

--- a/Godeps/_workspace/src/golang.org/x/net/html/parse_test.go
+++ b/Godeps/_workspace/src/golang.org/x/net/html/parse_test.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/appc/spec/Godeps/_workspace/src/golang.org/x/net/html/atom"
+	"golang.org/x/net/html/atom"
 )
 
 // readParseTest reads a single test case from r.

--- a/Godeps/_workspace/src/golang.org/x/net/html/token.go
+++ b/Godeps/_workspace/src/golang.org/x/net/html/token.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/appc/spec/Godeps/_workspace/src/golang.org/x/net/html/atom"
+	"golang.org/x/net/html/atom"
 )
 
 // A TokenType is the type of a Token.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/quantity.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/quantity.go
@@ -23,8 +23,8 @@ import (
 	"regexp"
 	"strings"
 
-	flag "github.com/appc/spec/Godeps/_workspace/src/github.com/spf13/pflag"
-	"github.com/appc/spec/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf"
+	flag "github.com/spf13/pflag"
+	"speter.net/go/exp/math/dec/inf"
 )
 
 // Quantity is a fixed-point representation of a number.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/quantity_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/quantity_test.go
@@ -21,9 +21,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/appc/spec/Godeps/_workspace/src/github.com/spf13/pflag"
-	"github.com/appc/spec/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf"
 	fuzz "github.com/google/gofuzz"
+	"github.com/spf13/pflag"
+	"speter.net/go/exp/math/dec/inf"
 )
 
 var (

--- a/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf/dec_test.go
+++ b/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf/dec_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/appc/spec/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf"
+	"speter.net/go/exp/math/dec/inf"
 )
 
 type decFunZZ func(z, x, y *inf.Dec) *inf.Dec

--- a/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf/example_test.go
+++ b/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf/example_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 )
 
-import "github.com/appc/spec/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf"
+import "speter.net/go/exp/math/dec/inf"
 
 func ExampleDec_SetString() {
 	d := new(inf.Dec)

--- a/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf/rounder_example_test.go
+++ b/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf/rounder_example_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/appc/spec/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf"
+	"speter.net/go/exp/math/dec/inf"
 )
 
 // This example displays the results of Dec.Round with each of the Rounders.

--- a/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf/rounder_test.go
+++ b/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf/rounder_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/appc/spec/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf"
+	"speter.net/go/exp/math/dec/inf"
 )
 
 var decRounderInputs = [...]struct {

--- a/build
+++ b/build
@@ -10,7 +10,7 @@ if [ ! -h gopath/src/${REPO_PATH} ]; then
 fi
 
 export GOBIN=${PWD}/bin
-export GOPATH=${PWD}/gopath
+export GOPATH=${PWD}/Godeps/_workspace:${PWD}/gopath
 
 eval $(go env)
 export GOOS GOARCH

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -22,8 +22,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/appc/spec/Godeps/_workspace/src/golang.org/x/net/html"
-	"github.com/appc/spec/Godeps/_workspace/src/golang.org/x/net/html/atom"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 type acMeta struct {

--- a/schema/image.go
+++ b/schema/image.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/appc/spec/schema/types"
 
-	"github.com/appc/spec/Godeps/_workspace/src/github.com/camlistore/go4/errorutil"
+	"github.com/camlistore/go4/errorutil"
 )
 
 const (

--- a/schema/pod.go
+++ b/schema/pod.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/appc/spec/schema/types"
 
-	"github.com/appc/spec/Godeps/_workspace/src/github.com/camlistore/go4/errorutil"
+	"github.com/camlistore/go4/errorutil"
 )
 
 const PodManifestKind = types.ACKind("PodManifest")

--- a/schema/types/isolator_resources.go
+++ b/schema/types/isolator_resources.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/appc/spec/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/resource"
 )
 
 var (

--- a/schema/types/isolator_resources_test.go
+++ b/schema/types/isolator_resources_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/appc/spec/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/resource"
 )
 
 func mustQuantity(s string) *resource.Quantity {

--- a/schema/types/semver.go
+++ b/schema/types/semver.go
@@ -17,7 +17,7 @@ package types
 import (
 	"encoding/json"
 
-	"github.com/appc/spec/Godeps/_workspace/src/github.com/coreos/go-semver/semver"
+	"github.com/coreos/go-semver/semver"
 )
 
 var (

--- a/schema/types/semver_test.go
+++ b/schema/types/semver_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/appc/spec/Godeps/_workspace/src/github.com/coreos/go-semver/semver"
+	"github.com/coreos/go-semver/semver"
 )
 
 func TestMarshalSemver(t *testing.T) {


### PR DESCRIPTION
Rewritten imports can make it difficult to vendor the code in other
packages. The only downside to un-rewriting (AFAICT) is that `actool` is
no longer `go get`able, but this is not something we endorsed in the
first place.