### PR TITLE
discovery: match template only if satisfies all required labels

### DIFF
--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -460,7 +460,9 @@ func TestDiscoverEndpoints(t *testing.T) {
 			[]string{"https://example.com/pubkeys.gpg"},
 			nil,
 		},
-		// Test multiple ACIEndpoints.
+		// Test multiple endpoints.
+		// Should render two endpoint, since '<meta name="ac-discovery" content="example.com https://storage.example.com/{name}-{version}.{ext}">'
+		// doesn't contain all the required labels
 		{
 			&mockHTTPDoer{
 				doer: fakeHTTPGet(
@@ -488,12 +490,39 @@ func TestDiscoverEndpoints(t *testing.T) {
 					ASC: "https://storage.example.com/example.com/myapp-1.0.0-linux-amd64.aci.asc",
 				},
 				ACIEndpoint{
-					ACI: "https://storage.example.com/example.com/myapp-1.0.0.aci",
-					ASC: "https://storage.example.com/example.com/myapp-1.0.0.aci.asc",
-				},
-				ACIEndpoint{
 					ACI: "hdfs://storage.example.com/example.com/myapp-1.0.0-linux-amd64.aci",
 					ASC: "hdfs://storage.example.com/example.com/myapp-1.0.0-linux-amd64.aci.asc",
+				},
+			},
+			[]string{"https://example.com/pubkeys.gpg"},
+			nil,
+		},
+		// Test a discovery string that has an hardcoded app name instead of using the provided {name}
+		{
+			&mockHTTPDoer{
+				doer: fakeHTTPGet(
+					[]meta{
+						{"/myapp",
+							"meta07.html",
+						},
+					},
+					nil,
+				),
+			},
+			true,
+			true,
+			App{
+				Name: "example.com/myapp",
+				Labels: map[types.ACIdentifier]string{
+					"version": "1.0.0",
+					"os":      "linux",
+					"arch":    "amd64",
+				},
+			},
+			[]ACIEndpoint{
+				ACIEndpoint{
+					ACI: "https://storage.example.com/myapp-1.0.0-linux-amd64.aci",
+					ASC: "https://storage.example.com/myapp-1.0.0-linux-amd64.aci.asc",
 				},
 			},
 			[]string{"https://example.com/pubkeys.gpg"},

--- a/discovery/testdata/meta07.html
+++ b/discovery/testdata/meta07.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+	<title>My app</title>
+	<meta name="ac-discovery" content="example.com/myapp https://storage.example.com/myapp-{version}-{os}-{arch}.{ext}">
+	<meta name="ac-discovery-pubkeys" content="example.com https://example.com/pubkeys.gpg">
+</head>
+
+<body>
+	<h1>My App</h1>
+</body>
+</html>

--- a/spec/discovery.md
+++ b/spec/discovery.md
@@ -59,6 +59,17 @@ curl $(echo "$urltmpl" | sed -e "s/{name}/$name/" -e "s/{version}/$version/" -e 
 
 where _name_, _version_, _os_, and _arch_ are set to their respective values for the image, and _ext_ is either `aci` or `aci.asc` for retrieving an App Container Image or signature respectively.
 
+The client MUST accept only templates that can be fully substituted and that satisfy all the required labels.
+
+For example given these meta tags:
+```html
+<meta name="ac-discovery" content="example.com https://storage.example.com/{os}/{arch}/{name}-{version}.{ext}">
+<meta name="ac-discovery" content="example.com https://storage.example.com/{os}/{arch}/{name}-latest.{ext}">
+```
+
+If the client requires the labels _name_, _version_, _os_, _arch_ only the first template will be rendered since the second doesn't satisfy the _version_ label.
+If the client requires the labels _name_, _os_, _arch_ only the second template will be rendered since in the first template '{version}' cannot be substituted.
+
 Note that multiple `ac-discovery` tags MAY be returned for a given prefix-match (for example, with different scheme names representing different transport mechanisms).
 In this case, the client implementation MAY choose which to use at its own discretion.
 Public discovery implementations SHOULD always provide at least one HTTPS URL template.


### PR DESCRIPTION
This is the first part that tries to implement #575 second proposal (remove the "hidden" behavior that sets a version label to "latest" if not provided)

Actually, the spec isn't clear on template rendering and matching and can block some meta tags implementation as, the current implementation, can return unwanted endpoints.

It can probably BREAK some of the current meta tags implementations. But I'd like to ear your thoughts on this since I cannot find better ideas.

--

discovery: match only templates that satisfy all required labels

Actually the spec doesn't clarify when an endpoint template should be accepted or
not. Now, the appc/spec implementation returns only endpoints that can
be fully rendered. This means that it will also accept a template if it
doesn't contain some of the required discovery labels.

This looks good, but, trying to implement some meta discovery ideas it
will bring to unwanted endpoints.

Example 1:
Suppose I want to implement the "latest" pattern behavior:

```html
<!-- ACIs with specific version -->
<meta name="ac-discovery" content="example.com https://storage.example.com/{name}-{version}-{os}-{arch}.{ext}">
<!-- Latest ACIs -->
<meta name="ac-discovery" content="example.com https://storage.example.com/{name}-latest-{os}-{arch}.{ext}">
```

If, on discovery, I ask for the _name_, _os_ and _arch_
labels only the second template will be rendered (since the first cannot
be fully rendered due to missing _version_ label). So I achieved latest
pattern.

But if I'm asking for a specific _version_ both templates will be
rendered.

Example 2:
As an extension of the first example, suppose I want to create a global
meta discovery for all my images on example.com. So on the root of my
server I'll put some meta tags using example.com as prefix:

```html
<!-- ACIs with specific version -->
<meta name="ac-discovery" content="example.com https://storage.example.com/{name}-{version}-{os}-{arch}.{ext}">
<!-- noarch ACIs -->
<meta name="ac-discovery" content="example.com https://storage.example.com/{name}-{version}-noarch.{ext}">
<!-- Latest ACIs -->
<meta name="ac-discovery" content="example.com https://storage.example.com/{name}-latest-{os}-{arch}.{ext}">
<meta name="ac-discovery" content="example.com https://storage.example.com/{name}-latest.{ext}">
```

With these tags I want to implement a "latest" and also "noarch" pattern.

If, on discovery, I ask only for the _name_ and _version_ labels the
second template will be rendered. So I achieved noarch pattern.

But, unfortunately, also the last template will be rendered.

And, as the first example, if I'm asking for a specific _name_,
_version_, _os_ and _arch_ ALL the templates will be rendered.

Since the spec says:
```
Note that multiple `ac-discovery` tags MAY be returned for a given
prefix-match [snip] In this case, the client implementation MAY choose
which to use at its own discretion.
```

If an implementation chooses the second it can download the wrong image version.

This patch makes template matching stricter choosing only template that
fully satisfy the required labels.

It can probably BREAK some of the current meta tags implementations.

It also documents this behavior.