### PR TITLE
spec: Added note that dependencies can form a directed acyclic graph

### DIFF
--- a/spec/ace.md
+++ b/spec/ace.md
@@ -15,7 +15,7 @@ This example pod will use a set of three apps:
 
 #### Pod UUID
 
-Each pod much be assigned an [RFC4122 UUID](http://www.ietf.org/rfc/rfc4122.txt). 
+Each pod much be assigned an [RFC4122 UUID](http://www.ietf.org/rfc/rfc4122.txt).
 The UUID serves as a canonical reference to a pod within a given administrative domain.
 In this context, an administrative domain is linked to the scope of the associated [Metadata Service](#app-container-metadata-service).
 For example, given a metadata service that is federated across a geographical cluster of systems, the pod UUID is uniquely scoped to the same cluster.
@@ -27,7 +27,7 @@ Each app in a pod will start chrooted into its own unique read-write filesystem 
 
 An app's filesystem must be *rendered* in an empty directory by the following process (or equivalent):
 
-1. If the ACI contains a non-empty `dependencies` field in its `ImageManifest`, the `rootfs` of each dependent image is extracted into the target directory, in the order in which they are listed. The multiple dependencies can form a tree. The dependencies are resolved in the depth-first order.
+1. If the ACI contains a non-empty `dependencies` field in its `ImageManifest`, the `rootfs` of each dependent image is extracted into the target directory, in the order in which they are listed. The multiple dependencies can form a tree or a [directed acyclic graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) if multiple dependencies have a common dependency. The dependencies are resolved in the depth-first order.
 2. The `rootfs` contained in the ACI is extracted into the target directory.
 3. If the ACI contains a non-empty `pathWhitelist` field in its `ImageManifest`, *all* paths not in the whitelist must be removed from the target directory. When extracting a file from an image, the file can be filtered by any of the `pathWhitelist` of the image itself and the images depending on the image.
 


### PR DESCRIPTION
Added a short note that dependencies can form a tree or a directed
acyclic graph as well if they share a common dependency.

FYI PR @jonboulle @krnowak @alban 

Following up on https://github.com/appc/spec/pull/555#issuecomment-201100795