### PR TITLE
discovery: fix HasPrefix in matching app name

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -148,6 +148,10 @@ func doDiscover(pre string, hostHeaders map[string]http.Header, app App, insecur
 		if !strings.HasPrefix(app.Name.String(), m.prefix) {
 			continue
 		}
+		if len(app.Name.String()) > len(m.prefix) &&
+			app.Name.String()[len(m.prefix)] != '/' {
+			continue
+		}
 
 		switch m.name {
 		case "ac-discovery":

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -531,6 +531,63 @@ func TestDiscoverEndpoints(t *testing.T) {
 			[]string{"https://example.com/pubkeys.gpg"},
 			testAuthHeader,
 		},
+
+		// Test for https://github.com/appc/spec/issues/592
+		{
+			&mockHTTPDoer{
+				doer: fakeHTTPGet(
+					[]meta{
+						{"",
+							"meta07.html",
+						},
+					},
+					nil,
+				),
+			},
+			true,
+			true,
+			App{
+				Name: "example.com/myapp",
+				Labels: map[types.ACIdentifier]string{
+					"version": "1.0.0",
+					"os":      "linux",
+					"arch":    "amd64",
+				},
+			},
+			[]ACIEndpoint{
+				ACIEndpoint{
+					ACI: "https://storage.example.com/myapp-1.0.0-linux-amd64.aci",
+					ASC: "https://storage.example.com/myapp-1.0.0-linux-amd64.aci.asc",
+				},
+			},
+			[]string{"https://example.com/pubkeys.gpg"},
+			nil,
+		},
+		{
+			&mockHTTPDoer{
+				doer: fakeHTTPGet(
+					[]meta{
+						{"",
+							"meta07.html",
+						},
+					},
+					nil,
+				),
+			},
+			false,
+			false,
+			App{
+				Name: "example.com/myappandothers",
+				Labels: map[types.ACIdentifier]string{
+					"version": "1.0.0",
+					"os":      "linux",
+					"arch":    "amd64",
+				},
+			},
+			nil,
+			nil,
+			nil,
+		},
 	}
 
 	for i, tt := range tests {

--- a/discovery/testdata/meta07.html
+++ b/discovery/testdata/meta07.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+	<title>My app</title>
+	<meta name="ac-discovery" content="example.com/myapp https://storage.example.com/myapp-{version}-{os}-{arch}.{ext}">
+	<meta name="ac-discovery-pubkeys" content="example.com https://example.com/pubkeys.gpg">
+</head>
+
+<body>
+	<h1>My App</h1>
+</body>
+</html>


### PR DESCRIPTION
The following meta:
  <meta name="ac-discovery" content="coreos.com/etcd https://github.com/coreos/etcd/releases/download/{version}/etcd-{version}-{os}-{arch}.{ext}">

Should make the following discoverable:
  actool discover coreos.com/etcd/fdfdsffds:v2.0.10
  actool discover coreos.com/etcd:v2.0.10

But not the following:
  actool discover coreos.com/etcdxxxxxxx:v2.0.10

This is now fixed by checking the character '/' in addition to
HasPrefix.

Fixes https://github.com/appc/spec/issues/592