### PR TITLE
spec/ace: add optional read-only rootfs field

### DIFF
--- a/schema/pod.go
+++ b/schema/pod.go
@@ -152,11 +152,12 @@ func (r Mount) assertValid() error {
 
 // RuntimeApp describes an application referenced in a PodManifest
 type RuntimeApp struct {
-	Name        types.ACName      `json:"name"`
-	Image       RuntimeImage      `json:"image"`
-	App         *types.App        `json:"app,omitempty"`
-	Mounts      []Mount           `json:"mounts,omitempty"`
-	Annotations types.Annotations `json:"annotations,omitempty"`
+	Name           types.ACName      `json:"name"`
+	Image          RuntimeImage      `json:"image"`
+	App            *types.App        `json:"app,omitempty"`
+	ReadOnlyRootFS bool              `json:"readOnlyRootFS,omitempty"`
+	Mounts         []Mount           `json:"mounts,omitempty"`
+	Annotations    types.Annotations `json:"annotations,omitempty"`
 }
 
 // RuntimeImage describes an image referenced in a RuntimeApp

--- a/spec/ace.md
+++ b/spec/ace.md
@@ -23,7 +23,8 @@ This UUID is exposed to the pod through the [Metadata Service](#app-container-me
 
 #### Filesystem Setup
 
-Each app in a pod will start chrooted into its own unique read-write filesystem before execution.
+Each app in a pod will start chrooted into its own unique filesystem before execution.
+If the app's entry in the `PodManifest` has the field `readOnlyRootFS` is set to `true`, the rootfs will be mounted as read-only for that app otherwise it will be mounted as read-write.
 
 An app's filesystem must be *rendered* in an empty directory by the following process (or equivalent):
 

--- a/spec/pods.md
+++ b/spec/pods.md
@@ -58,6 +58,7 @@ JSON Schema for the Pod Manifest, conforming to [RFC4627](https://tools.ietf.org
                     }
                 ]
             },
+            "readOnlyRootFS": true,
             "mounts": [
                 {
                     "volume": "worklib",
@@ -163,6 +164,7 @@ JSON Schema for the Pod Manifest, conforming to [RFC4627](https://tools.ietf.org
         * **name** (string, optional) name of the image (restricted to [AC Identifier](types.md#ac-identifier-type) formatting)
         * **labels** (list of objects, optional) additional labels characterizing the image
     * **app** (object, optional) substitute for the app object of the referred image's ImageManifest. See [Image Manifest Schema](aci.md#image-manifest-schema) for what the app object contains.
+    * **readOnlyRootFS** (boolean, optional, defaults to "false" if unsupplied) whether or not the root filesystem of the app will be mounted read-only.
     * **mounts** (list of objects, optional) list of mounts mapping an app mountPoint to a volume. Each mount has the following set of key-value pairs:
       * **volume** (string, required) name of the volume that will fulfill this mount (restricted to the [AC Name](types.md#ac-name-type) formatting); this is a key into the list of `volumes`, below.
       * **path** (string, required) path inside the app filesystem to mount the volume; generally this will come from one of an app's mountPoint paths. For example, if an app has a mountPoint named "work" with path "/var/lib/work", an executor should map an appropriate volume to fulfill that mountPoint by using a `mount` object with that path.


### PR DESCRIPTION
Adds `readOnlyRootFS` field for mounting rootfs of an app as read-only.

Fixes #245 

cc @jonboulle