### PR TITLE
isolator_resources.go: Fix build

### DIFF
--- a/schema/types/isolator_resources.go
+++ b/schema/types/isolator_resources.go
@@ -155,8 +155,8 @@ func NewResourceCPUIsolator(request, limit string) (*ResourceCPU, error) {
 	res := &ResourceCPU{
 		ResourceBase{
 			resourceValue{
-				Request: req,
-				Limit:   lim,
+				Request: &req,
+				Limit:   &lim,
 			},
 		},
 	}
@@ -209,8 +209,8 @@ func NewResourceMemoryIsolator(request, limit string) (*ResourceMemory, error) {
 	res := &ResourceMemory{
 		ResourceBase{
 			resourceValue{
-				Request: req,
-				Limit:   lim,
+				Request: &req,
+				Limit:   &lim,
 			},
 		},
 	}


### PR DESCRIPTION
resourceValue struct uses a pointer to resource.Quantity.

Before:
```
$ go build github.com/appc/spec/schema/types
# github.com/appc/spec/schema/types
./isolator_resources.go:158: cannot use req (type resource.Quantity) as type *resource.Quantity in field value
./isolator_resources.go:159: cannot use lim (type resource.Quantity) as type *resource.Quantity in field value
./isolator_resources.go:212: cannot use req (type resource.Quantity) as type *resource.Quantity in field value
./isolator_resources.go:213: cannot use lim (type resource.Quantity) as type *resource.Quantity in field value
```

After: It compiles.