### PR TITLE
spec: implement os/linux/no-new-privs isolator

### DIFF
--- a/actool/manifest.go
+++ b/actool/manifest.go
@@ -258,7 +258,19 @@ func patchManifest(im *schema.ImageManifest) error {
 				return fmt.Errorf("cannot parse isolator %q: %v", is, err)
 			}
 
-			if _, ok := types.ResourceIsolatorNames[name]; !ok {
+			_, ok := types.ResourceIsolatorNames[name]
+
+			if name == types.LinuxNoNewPrivilegesName {
+				ok = true
+				kv := strings.Split(is, ",")
+				if len(kv) != 2 {
+					return fmt.Errorf("isolator %s: invalid format", name)
+				}
+
+				isolatorStr = fmt.Sprintf(`{ "name": "%s", "value": %s }`, name, kv[1])
+			}
+
+			if !ok {
 				return fmt.Errorf("isolator %s is not supported for patching", name)
 			}
 

--- a/examples/image.json
+++ b/examples/image.json
@@ -56,6 +56,10 @@
             {
                 "name": "os/linux/capabilities-retain-set",
                 "value": {"set": ["CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE"]}
+            },
+            {
+                "name": "os/linux/no-new-privileges",
+                "value": true
             }
         ],
         "mountPoints": [

--- a/schema/types/isolator_linux_specific.go
+++ b/schema/types/isolator_linux_specific.go
@@ -22,6 +22,7 @@ import (
 const (
 	LinuxCapabilitiesRetainSetName = "os/linux/capabilities-retain-set"
 	LinuxCapabilitiesRevokeSetName = "os/linux/capabilities-remove-set"
+	LinuxNoNewPrivilegesName       = "os/linux/no-new-privileges"
 )
 
 var LinuxIsolatorNames = make(map[ACIdentifier]struct{})
@@ -30,10 +31,29 @@ func init() {
 	for name, con := range map[ACIdentifier]IsolatorValueConstructor{
 		LinuxCapabilitiesRevokeSetName: func() IsolatorValue { return &LinuxCapabilitiesRevokeSet{} },
 		LinuxCapabilitiesRetainSetName: func() IsolatorValue { return &LinuxCapabilitiesRetainSet{} },
+		LinuxNoNewPrivilegesName:       func() IsolatorValue { v := LinuxNoNewPrivileges(false); return &v },
 	} {
 		AddIsolatorName(name, LinuxIsolatorNames)
 		AddIsolatorValueConstructor(name, con)
 	}
+}
+
+type LinuxNoNewPrivileges bool
+
+func (l LinuxNoNewPrivileges) AssertValid() error {
+	return nil
+}
+
+func (l *LinuxNoNewPrivileges) UnmarshalJSON(b []byte) error {
+	var v bool
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	*l = LinuxNoNewPrivileges(v)
+
+	return nil
 }
 
 type LinuxCapabilitiesSet interface {

--- a/spec/ace.md
+++ b/spec/ace.md
@@ -195,6 +195,21 @@ Listing a capability in the remove set that is not in the default set such as `C
 In the example above, the process will only have the two capabilities in its bounding set.
 The retain set cannot be used in conjunction with the remove set.
 
+#### os/linux/no-new-privileges
+
+* Scope: app
+
+If set to true the app's process and all its children can never gain new privileges. For details see the corresponding kernel documentation about [prctl/no_new_privs.txt](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt).
+
+The default value is `false`.
+
+```json
+"name": "os/linux/no-new-privileges",
+"value": true
+```
+
+In the example above, the process will have `no_new_privs` set. If the app's executable has i.e. setuid/setgid bits set they will be ignored.
+
 ### Resource Isolators
 
 A _resource_ is something that can be consumed by an application (app) or group of applications (pod), such as memory (RAM), CPU, and network bandwidth.


### PR DESCRIPTION
This adds a new no-new-privs isolator type.

actool support was added for patching a manifest:
`actool patch-manifest -isolators='os/linux/no-new-privs,true'`.

This is a prerequisite for https://github.com/coreos/rkt/issues/1469.