### PR TITLE
build/test: fail on Go1 .5

### DIFF
--- a/build
+++ b/build
@@ -11,7 +11,7 @@ fi
 
 export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
-#export GOPATH=${PWD}/Godeps/_workspace:${PWD}/gopath
+export GO15VENDOREXPERIMENT=1
 
 eval $(go env)
 export GOOS GOARCH


### PR DESCRIPTION
Go 1.5 needs the environment flag `GO15VENDOREXPERIMENT=1` set to detect the deps in the _vendor/_ directory. Ideally it would be done dynamically, but could just be added to the scripts statically too.

/cc @jonboulle 