### PR TITLE
ace: add Linux-specific seccomp isolator

### DIFF
--- a/examples/image.json
+++ b/examples/image.json
@@ -60,6 +60,17 @@
             {
                 "name": "os/linux/no-new-privileges",
                 "value": true
+            },
+            {
+                "name": "os/linux/seccomp-remove-set",
+                "value": {
+                    "errno": "EACCESS",
+                    "set": [
+                        "clock_settime",
+                        "clock_adjtime",
+                        "reboot"
+                    ]
+                }
             }
         ],
         "mountPoints": [

--- a/schema/types/app.go
+++ b/schema/types/app.go
@@ -86,5 +86,8 @@ func (a *App) assertValid() error {
 	if err := a.Environment.assertValid(); err != nil {
 		return err
 	}
+	if err := a.Isolators.assertValid(); err != nil {
+		return err
+	}
 	return nil
 }

--- a/schema/types/isolator.go
+++ b/schema/types/isolator.go
@@ -16,10 +16,14 @@ package types
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 )
 
 var (
 	isolatorMap map[ACIdentifier]IsolatorValueConstructor
+
+	ErrIncompatibleIsolator = errors.New("isolators set contains incompatible types")
 )
 
 func init() {
@@ -40,6 +44,29 @@ func AddIsolatorName(n ACIdentifier, ns map[ACIdentifier]struct{}) {
 // and PodManifest schemas.
 type Isolators []Isolator
 
+// assertValid checks that every single isolator is valid and that
+// the whole set is well built
+func (isolators Isolators) assertValid() error {
+	typesMap := make(map[ACIdentifier]bool)
+	for _, i := range isolators {
+		if err := i.Value().AssertValid(); err != nil {
+			return err
+		}
+		if _, ok := typesMap[i.Name]; ok {
+			if !i.Value().multipleAllowed() {
+				return fmt.Errorf(`isolators set contains too many instances of type %s"`, i.Name)
+			}
+		}
+		for _, c := range i.Value().Conflicts() {
+			if _, found := typesMap[c]; found {
+				return ErrIncompatibleIsolator
+			}
+		}
+		typesMap[i.Name] = true
+	}
+	return nil
+}
+
 // GetByName returns the last isolator in the list by the given name.
 func (is *Isolators) GetByName(name ACIdentifier) *Isolator {
 	var i Isolator
@@ -50,6 +77,22 @@ func (is *Isolators) GetByName(name ACIdentifier) *Isolator {
 		}
 	}
 	return nil
+}
+
+// ReplaceIsolatorsByName overrides matching isolator types with a new
+// isolator, deleting them all and appending the new one instead
+func (is *Isolators) ReplaceIsolatorsByName(newIs Isolator, oldNames []ACIdentifier) {
+	var i Isolator
+	for j := len(*is) - 1; j >= 0; j-- {
+		i = []Isolator(*is)[j]
+		for _, name := range oldNames {
+			if i.Name == name {
+				*is = append((*is)[:j], (*is)[j+1:]...)
+			}
+		}
+	}
+	*is = append((*is)[:], newIs)
+	return
 }
 
 // Unrecognized returns a set of isolators that are not recognized.
@@ -69,8 +112,17 @@ func (is *Isolators) Unrecognized() Isolators {
 // serialized as any arbitrary JSON blob. Specific Isolator types should
 // implement this interface to facilitate unmarshalling and validation.
 type IsolatorValue interface {
+	// UnmarshalJSON unserialize a JSON-encoded isolator
 	UnmarshalJSON(b []byte) error
+	// AssertValid returns a non-nil error value if an IsolatorValue is not valid
+	// according to appc spec
 	AssertValid() error
+	// Conflicts returns a list of conflicting isolators types, which cannot co-exist
+	// together with this IsolatorValue
+	Conflicts() []ACIdentifier
+	// multipleAllowed specifies whether multiple isolator instances are allowed
+	// for this isolator type
+	multipleAllowed() bool
 }
 
 // Isolator is a model for unmarshalling isolator types from their JSON-encoded

--- a/schema/types/isolator_resources.go
+++ b/schema/types/isolator_resources.go
@@ -85,6 +85,15 @@ func (r ResourceBase) AssertValid() error {
 	return nil
 }
 
+// TODO(lucab): both need to be clarified in spec,
+// see https://github.com/appc/spec/issues/625
+func (l ResourceBase) multipleAllowed() bool {
+	return true
+}
+func (l ResourceBase) Conflicts() []ACIdentifier {
+	return nil
+}
+
 type ResourceBlockBandwidth struct {
 	ResourceBase
 }


### PR DESCRIPTION
This is a proposal for two Linux-specific security isolators based on [seccomp filters](https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt). It follows closely the capabilities isolators, where two modes are provided: "remove-set" (blacklisting) and "retain-set" (whitelisting).

Given the huge number of syscalls that can be specified this way and the on-going discussion about sensible defaults, this specification doesn't hardcode any list but let implementations some freedom to provide groups/wildcards via `@`-prefixed special values. Users can decide to provide their own custom filters, or just opt-in/opt-out those implementations-provided filters.

Fixes #529