### PR TITLE
schema/app: add parameter to set support of sd_notify()

### DIFF
--- a/examples/image.json
+++ b/examples/image.json
@@ -128,6 +128,10 @@
         {
             "name": "homepage",
             "value": "https://example.com"
+        },
+        {
+            "name": "appc.io/executor/supports-systemd-notify",
+            "value": "false"
         }
     ]
 }

--- a/schema/types/annotations_test.go
+++ b/schema/types/annotations_test.go
@@ -79,6 +79,12 @@ func TestAnnotationsAssertValid(t *testing.T) {
 			},
 			false,
 		},
+		{
+			[]Annotation{
+				makeAnno("appc.io/executor/supports-systemd-notify", "false"),
+			},
+			false,
+		},
 		// empty is OK
 		{
 			[]Annotation{},

--- a/spec/aci.md
+++ b/spec/aci.md
@@ -211,6 +211,10 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest), conformin
         {
             "name": "homepage",
             "value": "https://example.com"
+        },
+        {
+            "name": "appc.io/executor/supports-systemd-notify",
+            "value": false
         }
     ]
 }
@@ -250,6 +254,7 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest), conformin
     * **authors** contact details of the people or organization responsible for the image (freeform string)
     * **homepage** URL to find more information on the image (string, must be a URL with scheme HTTP or HTTPS)
     * **documentation** URL to get documentation on the image (string, must be a URL with scheme HTTP or HTTPS)
+    * **appc.io/executor/supports-systemd-notify** (boolean, optional, defaults to "false" if unset) if set to true, the application SHOULD use the sd\_notify mechanism to signal when it is ready. Also it SHOULD be able to detect if the executor had not set up the sd\_notify mechanism and skip the notification without error ([sd_notify()](https://www.freedesktop.org/software/systemd/man/sd_notify.html) from libsystemd does that automatically).
 
 #### Dependency Matching
 


### PR DESCRIPTION
supportNotify exposes if or not an application supports notifications
using sd_notify(). This information may be used to signal the init
process when a service is ready.