### PR TITLE
discovery: add port parameters

### DIFF
--- a/actool/discover.go
+++ b/actool/discover.go
@@ -29,9 +29,10 @@ var (
 		Name:        "discover",
 		Description: "Discover the download URLs for an app",
 		Summary:     "Discover the download URLs for one or more app container images",
-		Usage:       "[--json] APP...",
+		Usage:       "[--json] [--port] [--insecure] APP...",
 		Run:         runDiscover,
 	}
+	flagPort uint
 )
 
 func init() {
@@ -39,6 +40,8 @@ func init() {
 		"Don't check TLS certificates and allow insecure non-TLS downloads over http")
 	cmdDiscover.Flags.BoolVar(&outputJson, "json", false,
 		"Output result as JSON")
+	cmdDiscover.Flags.UintVar(&flagPort, "port", 0,
+		"Port to connect to when performing discovery")
 }
 
 func runDiscover(args []string) (exit int) {
@@ -62,7 +65,7 @@ func runDiscover(args []string) (exit int) {
 		if transportFlags.Insecure {
 			insecure = discovery.InsecureTLS | discovery.InsecureHTTP
 		}
-		eps, attempts, err := discovery.DiscoverACIEndpoints(*app, nil, insecure)
+		eps, attempts, err := discovery.DiscoverACIEndpoints(*app, nil, insecure, flagPort)
 		if err != nil {
 			stderr("error fetching endpoints for %s: %s", name, err)
 			return 1
@@ -70,7 +73,7 @@ func runDiscover(args []string) (exit int) {
 		for _, a := range attempts {
 			fmt.Printf("discover endpoints walk: prefix: %s error: %v\n", a.Prefix, a.Error)
 		}
-		publicKeys, attempts, err := discovery.DiscoverPublicKeys(*app, nil, insecure)
+		publicKeys, attempts, err := discovery.DiscoverPublicKeys(*app, nil, insecure, flagPort)
 		if err != nil {
 			stderr("error fetching public keys for %s: %s", name, err)
 			return 1

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -549,7 +549,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			InsecureTLS | InsecureHTTP,
 		}
 		for _, insecure := range insecureList {
-			eps, _, err := DiscoverACIEndpoints(tt.app, hostHeaders, insecure)
+			eps, _, err := DiscoverACIEndpoints(tt.app, hostHeaders, insecure, 0)
 			if err != nil && !tt.expectDiscoveryACIEndpointsSuccess {
 				continue
 			}
@@ -559,7 +559,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			if err != nil {
 				t.Fatalf("#%d DiscoverACIEndpoints failed: %v", i, err)
 			}
-			publicKeys, _, err := DiscoverPublicKeys(tt.app, hostHeaders, insecure)
+			publicKeys, _, err := DiscoverPublicKeys(tt.app, hostHeaders, insecure, 0)
 			if err != nil && !tt.expectDiscoveryPublicKeysSuccess {
 				continue
 			}

--- a/discovery/http_test.go
+++ b/discovery/http_test.go
@@ -194,7 +194,7 @@ func TestHTTPSOrHTTP(t *testing.T) {
 		hostHeaders := map[string]http.Header{
 			tt.name: tt.authHeader,
 		}
-		urlStr, body, err := httpsOrHTTP(tt.name, hostHeaders, tt.insecure)
+		urlStr, body, err := httpsOrHTTP(tt.name, hostHeaders, tt.insecure, 0)
 		if tt.expectSuccess {
 			if err != nil {
 				t.Fatalf("#%d httpsOrHTTP failed: %v", i, err)


### PR DESCRIPTION
Currently the ACI spec only supports discovery on ports 443 and 80, this
does not allow using a discovery server on any other ports.

This commit adds an argument allowing for discovery on arbitrary ports.
If the argument is not specified (as in, is 0), the default ports are
used.

Replaces https://github.com/appc/spec/pull/110#issuecomment-227428866.
Prompted by https://github.com/appc/acpush/issues/6.