### PR TITLE
Added amd64 as a valid architecture on darwin

### DIFF
--- a/schema/types/labels.go
+++ b/schema/types/labels.go
@@ -23,7 +23,7 @@ import (
 var ValidOSArch = map[string][]string{
 	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b"},
 	"freebsd": {"amd64", "i386", "arm"},
-	"darwin":  {"x86_64", "i386"},
+	"darwin":  {"amd64", "x86_64", "i386"},
 }
 
 type Labels []Label


### PR DESCRIPTION
Added "amd64" as a valid OS architecture for darwin.

Based on the output of `go env`, I believe this should be a valid architecture for darwin

```
go env | grep GOARCH

GOARCH="amd64"
```

My OS X version:

```
sw_vers
ProductName:    Mac OS X
ProductVersion: 10.10.5
BuildVersion:   14F1808
```
