### PR TITLE
schema: add ppc64le/ppc64 as valid linux archs

### DIFF
--- a/schema/types/labels.go
+++ b/schema/types/labels.go
@@ -21,7 +21,7 @@ import (
 )
 
 var ValidOSArch = map[string][]string{
-	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b"},
+	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b", "ppc64", "ppc64le"},
 	"freebsd": {"amd64", "i386", "arm"},
 	"darwin":  {"x86_64", "i386"},
 }

--- a/schema/types/labels_test.go
+++ b/schema/types/labels_test.go
@@ -62,6 +62,26 @@ func TestLabels(t *testing.T) {
 			"",
 		},
 		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "ppc64le"}]`,
+			"",
+		},
+		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "ppc64l"}]`,
+			`bad arch "ppc64l" for linux`,
+		},
+		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "ppc64"}]`,
+			"",
+		},
+		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "ppc64b"}]`,
+			`bad arch "ppc64b" for linux`,
+		},
+		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "ppc64be"}]`,
+			`bad arch "ppc64be" for linux`,
+		},
+		{
 			`[{"name": "os", "value": "freebsd"}, {"name": "arch", "value": "amd64"}]`,
 			"",
 		},


### PR DESCRIPTION
This adds labeling for the two endian variants of ppc64:
`ppc64le` for little-endian and `ppc64` for big-endian.

These explicitly correspond to `uname -m` on Linux systems.