### PR TITLE
Expand ACI acronym so that it's clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The App Container (appc) spec aims to have the following properties:
 
 ## What is the promise of the App Container Spec?
 
-By explicitly defining - separate of any particular implementation - how an app is packaged into an image, downloaded over a network, and executed as a container, we hope to enable a community of engineers to build tooling around the fundamental building block of a container.
+By explicitly defining - separate of any particular implementation - how an app is packaged into an App Container Image (ACI), downloaded over a network, and executed as a container, we hope to enable a community of engineers to build tooling around the fundamental building block of a container.
 Some examples of build systems and tools that have been built so far include:
 
 - [goaci](https://github.com/appc/goaci) - ACI builder for Go projects


### PR DESCRIPTION
The "ACI" acronym starts to be relevant since the very beginning, but it's not defined anywhere in the starting page. I think it's important to have its expansion early to improve clarity.