### PR TITLE
discovery: increase default connection timeout

### DIFF
--- a/discovery/http.go
+++ b/discovery/http.go
@@ -28,7 +28,7 @@ import (
 type InsecureOption int
 
 const (
-	defaultDialTimeout = 5 * time.Second
+	defaultDialTimeout = 20 * time.Second
 )
 
 const (


### PR DESCRIPTION
This commit increases default connection timeout from 5s to 20s,
in order to gracefully accomodate for retrials. This will help in
overcoming soft-failure cases, like skipping a single faulty
resolvers in resolv.conf.

This is still a quite aggressive timeout, well below the Linux
timeout of 127s for new TCP connections.