### PR TITLE
scripts: consolidate and tweak build/release

### DIFF
--- a/scripts/build-ace-validator-acis
+++ b/scripts/build-ace-validator-acis
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 #
-# Builds an ACI containing a go implementation of an ACE validator
-#
 set -eu
 
 PREFIX="ace"
@@ -9,7 +7,7 @@ PREFIX="ace"
 GOOS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"
 
-if ! [[ $0 =~ "${PREFIX}/build_aci" ]]; then 
+if ! [[ $0 =~ "scripts/build-ace-validator-acis" ]]; then 
 	echo "invoke from repository root" 1>&2
 	exit 255
 fi
@@ -19,7 +17,7 @@ if ! [[ -f "bin/ace-validator" ]]; then
 fi
 
 for typ in main sidekick; do 
-	layoutdir="bin/ace-${typ}-layout"
+	layoutdir="bin/ace-validator-${typ}-layout"
 	mkdir -p ${layoutdir}/rootfs/opt/acvalidator
 	cp bin/ace-validator ${layoutdir}/rootfs/
 	sed -e "s/@GOOS@/$GOOS/" -e "s/@GOARCH@/$GOARCH/" < ${PREFIX}/image_manifest_${typ}.json.in > ${layoutdir}/manifest
@@ -31,17 +29,12 @@ for typ in main sidekick; do
 			touch -a -m -d 1970-01-01T00:00:00Z ${path}
 		done
 		../actool build --overwrite ./ ../ace-validator-${typ}.aci
-		# TODO(jonboulle): create uncompressed instead, then gzip?
-		HASH=sha512-$(gzip -d -f ../ace-validator-${typ}.aci -c | openssl dgst -sha512 -hex -r | awk '{print $1}')
 		if [ -z "$NO_SIGNATURE" ] ; then
 			gpg --cipher-algo AES256 --armor --output ace-validator-${typ}.aci.asc --detach-sig ../ace-validator-${typ}.aci
 			mv ace-validator-${typ}.aci.asc ../
 		fi
 	popd >/dev/null
-	echo "Wrote ${typ} layout to      ${layoutdir}"
 	echo "Wrote unsigned ${typ} ACI   bin/ace-validator-${typ}.aci"
-	ln -s ${PWD}/bin/ace-validator-${typ}.aci bin/${HASH}
-	echo "Wrote ${typ} layout hash    bin/${HASH}"
 	if [ -f "bin/ace-validator-${typ}.aci.asc" ]; then
 		echo "Wrote ${typ} ACI signature  bin/ace-validator-${typ}.aci.asc"
 	fi

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -11,10 +11,27 @@ if ! [[ "$1" =~ ^v[[:digit:]]+.[[:digit:]]+.[[:digit:]]$ ]]; then
 fi
 
 ver="appc-${1}"
+releasedir="release-${ver}"
 mkdir "${ver}"
+mkdir "release-${ver}"
+
 git checkout "${1}"
 	./build
-	cp bin/actool "${ver}/"
-	cp SPEC.md "${ver}/"
+	cp -r bin/actool SPEC.md spec/ "${ver}/"
 	tar czvf "${ver}.tar.gz" "${ver}"
+	echo "Wrote release tarball ${ver}.tar.gz"
+	rm -fr "${ver}"
+	gpg --detach-sign "${ver}.tar.gz"
+	mv "${ver}.tar.gz" "${ver}.tar.gz.sig" "${releasedir}/"
+
+	echo "Building ACE validators"
+	if [[ -f scripts/build-ace-validator-acis ]]; then
+		scripts/build-ace-validator-acis
+	else
+		ace/build_aci # backwards-compatible fallback
+	fi
+	cp bin/ace-validator-{main,sidekick}.aci{,.asc} "${releasedir}/"
+
 git checkout -
+
+echo "Done. Release artifacts in ${releasedir}/"


### PR DESCRIPTION
- Move ace/build_aci to more appropriate location and name
  and remove legacy hash/layout information
- Update release script with debugging information and invoking
  ACE build, to make it less likely to forgot to release these too
  in future

/cc @lucab