### PR TITLE
schema: add s390x as a valid linux architecture

### DIFF
--- a/schema/types/labels.go
+++ b/schema/types/labels.go
@@ -21,7 +21,7 @@ import (
 )
 
 var ValidOSArch = map[string][]string{
-	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b", "ppc64", "ppc64le"},
+	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b", "ppc64", "ppc64le", "s390x"},
 	"freebsd": {"amd64", "i386", "arm"},
 	"darwin":  {"x86_64", "i386"},
 }

--- a/schema/types/labels_test.go
+++ b/schema/types/labels_test.go
@@ -82,6 +82,14 @@ func TestLabels(t *testing.T) {
 			`bad arch "ppc64be" for linux`,
 		},
 		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "s390x"}]`,
+			``,
+		},
+		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "S390x"}]`,
+			`bad arch "S390x" for linux`,
+		},
+		{
 			`[{"name": "os", "value": "freebsd"}, {"name": "arch", "value": "amd64"}]`,
 			"",
 		},


### PR DESCRIPTION
This adds a new `s390x` architecture label for linux.
It maps to IBM z/Architecture: https://en.wikipedia.org/wiki/Z/Architecture

`s390x` is a 64-bits, aligned access, big-endian architecture:
https://wiki.debian.org/ArchitectureSpecificsMemo

This new label corresponds to `uname -m` on Linux systems, to GOARCH and
to the usual distro naming.
The usual GNU triplet for this is `s390x-ibm-linux-gnu`.