### PR TITLE
schema/types: translate between appc<->go arch tuples

### DIFF
--- a/schema/types/labels_test.go
+++ b/schema/types/labels_test.go
@@ -22,99 +22,171 @@ import (
 
 func TestLabels(t *testing.T) {
 	tests := []struct {
-		in        string
-		errPrefix string
+		in           string
+		goOS         string
+		goArch       string
+		goArchFlavor string
+		errPrefix    string
 	}{
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "amd64"}]`,
+			"linux",
+			"amd64",
+			"",
 			"",
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "aarch64"}]`,
+			"linux",
+			"arm64",
+			"",
 			"",
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "arm64"}]`,
+			"",
+			"",
+			"",
 			`bad arch "arm64" for linux`,
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "aarch64_be"}]`,
 			"",
+			"",
+			"",
+			"",
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "arm64_be"}]`,
+			"",
+			"",
+			"",
 			`bad arch "arm64_be" for linux`,
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "arm"}]`,
+			"",
+			"",
+			"",
 			`bad arch "arm" for linux`,
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "armv6l"}]`,
+			"linux",
+			"arm",
+			"6",
 			"",
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "armv7l"}]`,
+			"linux",
+			"arm",
+			"7",
 			"",
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "armv7b"}]`,
 			"",
+			"",
+			"",
+			"",
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "ppc64le"}]`,
+			"linux",
+			"ppc64le",
+			"",
 			"",
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "ppc64l"}]`,
+			"",
+			"",
+			"",
 			`bad arch "ppc64l" for linux`,
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "ppc64"}]`,
+			"linux",
+			"ppc64",
+			"",
 			"",
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "ppc64b"}]`,
+			"",
+			"",
+			"",
 			`bad arch "ppc64b" for linux`,
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "ppc64be"}]`,
+			"",
+			"",
+			"",
 			`bad arch "ppc64be" for linux`,
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "s390x"}]`,
-			``,
+			"linux",
+			"s390x",
+			"",
+			"",
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "S390x"}]`,
+			"",
+			"",
+			"",
 			`bad arch "S390x" for linux`,
 		},
 		{
 			`[{"name": "os", "value": "freebsd"}, {"name": "arch", "value": "amd64"}]`,
+			"freebsd",
+			"amd64",
+			"",
 			"",
 		},
 		{
 			`[{"name": "os", "value": "OS/360"}, {"name": "arch", "value": "S/360"}]`,
+			"",
+			"",
+			"",
 			`bad os "OS/360"`,
 		},
 		{
 			`[{"name": "os", "value": "freebsd"}, {"name": "arch", "value": "armv7b"}]`,
+			"",
+			"",
+			"",
 			`bad arch "armv7b" for freebsd`,
 		},
 		{
 			`[{"name": "name"}]`,
+			"",
+			"",
+			"",
 			`invalid label name: "name"`,
 		},
 		{
 			`[{"name": "os", "value": "linux"}, {"name": "os", "value": "freebsd"}]`,
+			"",
+			"",
+			"",
 			`duplicate labels of name "os"`,
 		},
 		{
 			`[{"name": "arch", "value": "amd64"}, {"name": "os", "value": "freebsd"}, {"name": "arch", "value": "x86_64"}]`,
+			"",
+			"",
+			"",
 			`duplicate labels of name "arch"`,
 		},
 		{
 			`[]`,
+			"",
+			"",
+			"",
 			"",
 		},
 	}
@@ -130,6 +202,21 @@ func TestLabels(t *testing.T) {
 			t.Log(l)
 			if tt.errPrefix != "" {
 				t.Errorf("#%d: got no err, expected prefix %#v", i, tt.errPrefix)
+			}
+			jsonOs, _ := l.Get("os")
+			jsonArch, _ := l.Get("arch")
+			os, arch, flavor, _ := ToGoOSArch(jsonOs, jsonArch)
+			if os != tt.goOS {
+				t.Errorf("#%d: got os %q, expected os %q", i, os, tt.goOS)
+
+			}
+			if arch != tt.goArch {
+				t.Errorf("#%d: got arch %q, expected arch %q", i, arch, tt.goArch)
+
+			}
+			if flavor != tt.goArchFlavor {
+				t.Errorf("#%d: got flavor %q, expected flavor %q", i, flavor, tt.goArchFlavor)
+
 			}
 		}
 	}


### PR DESCRIPTION
This commit introduces two helper functions to translate between
appc and golang os/architecture labels.

Closes https://github.com/appc/spec/issues/665