### PR TITLE
spec: add os/linux/selinux-context isolator

### DIFF
--- a/schema/types/isolator_linux_specific_test.go
+++ b/schema/types/isolator_linux_specific_test.go
@@ -57,6 +57,76 @@ func TestNewLinuxCapabilitiesRetainSet(t *testing.T) {
 
 }
 
+func TestNewLinuxSELinuxContext(t *testing.T) {
+	tests := []struct {
+		inUser  string
+		inRole  string
+		inType  string
+		inLevel string
+
+		wuser  LinuxSELinuxUser
+		wrole  LinuxSELinuxRole
+		wtype  LinuxSELinuxType
+		wlevel LinuxSELinuxLevel
+		werr   bool
+	}{
+		{
+			"unconfined_u", "object_r", "user_home_t", "s0",
+			LinuxSELinuxUser("unconfined_u"),
+			LinuxSELinuxRole("object_r"),
+			LinuxSELinuxType("user_home_t"),
+			LinuxSELinuxLevel("s0"),
+			false,
+		},
+		{
+			"unconfined_u", "object_r", "user_home_t", "s0-s0:c0",
+			LinuxSELinuxUser("unconfined_u"),
+			LinuxSELinuxRole("object_r"),
+			LinuxSELinuxType("user_home_t"),
+			LinuxSELinuxLevel("s0-s0:c0"),
+			false,
+		},
+		{
+			"", "object_r", "user_home_t", "s0",
+			"",
+			"",
+			"",
+			"",
+			true,
+		},
+		{
+			"unconfined_u:unconfined_t", "object_r", "user_home_t", "s0",
+			"",
+			"",
+			"",
+			"",
+			true,
+		},
+	}
+	for i, tt := range tests {
+		c, err := NewLinuxSELinuxContext(tt.inUser, tt.inRole, tt.inType, tt.inLevel)
+		if tt.werr {
+			if err == nil {
+				t.Errorf("#%d: did not get expected error", i)
+			}
+			continue
+		}
+		if guser := c.User(); !reflect.DeepEqual(guser, tt.wuser) {
+			t.Errorf("#%d: got user %#v, want user %#v", i, guser, tt.wuser)
+		}
+		if grole := c.Role(); !reflect.DeepEqual(grole, tt.wrole) {
+			t.Errorf("#%d: got role %#v, want role %#v", i, grole, tt.wrole)
+		}
+		if gtype := c.Type(); !reflect.DeepEqual(gtype, tt.wtype) {
+			t.Errorf("#%d: got type %#v, want type %#v", i, gtype, tt.wtype)
+		}
+		if glevel := c.Level(); !reflect.DeepEqual(glevel, tt.wlevel) {
+			t.Errorf("#%d: got level %#v, want level %#v", i, glevel, tt.wlevel)
+		}
+	}
+
+}
+
 func TestNewLinuxCapabilitiesRevokeSet(t *testing.T) {
 	tests := []struct {
 		in []string

--- a/schema/types/isolator_test.go
+++ b/schema/types/isolator_test.go
@@ -256,6 +256,34 @@ func TestIsolatorUnmarshal(t *testing.T) {
 			}`,
 			true,
 		},
+		{
+			`{
+				"name": "os/linux/selinux-context",
+				"value": {"user" : "user_u", "role": "role_r", "type": "type_r", "level": "s0-s0"}
+			}`,
+			false,
+		},
+		{
+			`{
+				"name": "os/linux/selinux-context",
+				"value": {"user" : "user_u", "role": "role_r", "type": "type_r", "level": "s0-s0:c0"}
+			}`,
+			false,
+		},
+		{
+			`{
+				"name": "os/linux/selinux-context",
+				"value": {"user" : "user_u", "role": "role_r:type_t", "type": "type_r", "level": "s0-s0"}
+			}`,
+			true,
+		},
+		{
+			`{
+				"name": "os/linux/selinux-context",
+				"value": {"user" : "user_u", "role": "", "type": "type_r", "level": "s0-s0"}
+			}`,
+			true,
+		},
 	}
 
 	for i, tt := range tests {

--- a/spec/ace.md
+++ b/spec/ace.md
@@ -200,6 +200,38 @@ In the example above, the process will not be allowed to invoke `clock_adjtime(2
 
 In the example above, the process will be only allowed to invoke syscalls specified in the custom network-related set (and any other syscall in the implementation-specific whitelist). All other syscalls will result in app termination via `SIGSYS` signal.
 
+#### os/linux/selinux-context
+
+* Scope: app/pod
+
+**Parameters:**
+
+* **user** case-sensitive string containing the user portion of the SELinux security context to be used to label the current pod or application.
+* **role** case-sensitive string containing the role portion of the SELinux security context to be used to label the current pod or application.
+* **type** case-sensitive string containing the type/domain portion of the SELinux security context to be used to label the current pod or application.
+* **level** case-sensitive string containing the level portion of the SELinux security context to be used to label the current pod or application.
+
+**Notes:**
+ 1. Only a single `os/linux/selinux-context` isolator can be specified per-pod.
+ 2. Only a single `os/linux/selinux-context` isolator can be specified per-app.
+ 3. If a SELinux security context is specified at pod level, it applies to all processes involved in running the pod.
+ 4. If specified both at pod and app level, app values override pod ones.
+ 5. Implementations MAY ignore this isolator if the host does not support SELinux labeling.
+
+**Example:**
+
+```json
+"name": "os/linux/selinux-context",
+"value": {
+  "user": "system_u",
+  "role": "system_r",
+  "type": "dhcpc_t",
+  "level": "s0",
+}
+```
+
+In the example above, the SELinux security context `system_u:system_r:dhcpc_t:s0` will be applied to a pod or to a single application, depending on where this isolator is specified.
+
 #### os/linux/capabilities-remove-set
 
 * Scope: app


### PR DESCRIPTION
This commit introduces an "os/linux/selinux-context" isolator, which
can be applied at both app and pod scope.