### PR TITLE
pod: now reject duplicate volume names in manifest

### DIFF
--- a/schema/pod.go
+++ b/schema/pod.go
@@ -83,6 +83,15 @@ func (pm *PodManifest) assertValid() error {
 	if pm.ACKind != PodManifestKind {
 		return pmKindError
 	}
+
+	// ensure volumes names are unique (unique key)
+	volNames := make(map[types.ACName]bool, len(pm.Volumes))
+	for _, vol := range pm.Volumes {
+		if volNames[vol.Name] {
+			return fmt.Errorf("duplicate volume name %q", vol.Name)
+		}
+		volNames[vol.Name] = true
+	}
 	return nil
 }
 

--- a/schema/pod_test.go
+++ b/schema/pod_test.go
@@ -71,3 +71,43 @@ func TestAppList(t *testing.T) {
 		t.Errorf("want err, got nil")
 	}
 }
+
+func TestPodManifestUniqueVolumeNames(t *testing.T) {
+	pm := BlankPodManifest()
+	volA, err := types.VolumeFromString("simple,kind=empty")
+	if err != nil {
+		t.Errorf("expected nil error, got %q", err)
+	}
+	volB, err := types.VolumeFromString("simple,kind=host,source=/tmp")
+	if err != nil {
+		t.Errorf("expected nil error, got %q", err)
+	}
+	pm.Volumes = append(pm.Volumes, *volA, *volB)
+	if _, err := pm.MarshalJSON(); err == nil {
+		t.Errorf("expected duplicate volume name error, got nil")
+	}
+
+	pmj := `
+{
+        "acVersion": "0.8.10",
+        "acKind": "PodManifest",
+        "apps": [
+        ],
+        "volumes": [
+                {
+                        "name": "simplename",
+                        "kind": "empty"
+                },
+                {
+                        "name": "simplename",
+                        "kind": "host",
+                        "source": "/tmp"
+                }
+        ]
+}
+`
+	err = pm.UnmarshalJSON([]byte(pmj))
+	if err == nil {
+		t.Errorf("expected duplicate volume name error, got nil")
+	}
+}

--- a/spec/aci.md
+++ b/spec/aci.md
@@ -214,7 +214,7 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest), conformin
         },
         {
             "name": "appc.io/executor/supports-systemd-notify",
-            "value": false
+            "value": "false"
         }
     ]
 }
@@ -256,7 +256,7 @@ JSON Schema for the Image Manifest (app image manifest, ACI manifest), conformin
     * **authors** contact details of the people or organization responsible for the image (freeform string)
     * **homepage** URL to find more information on the image (string, must be a URL with scheme HTTP or HTTPS)
     * **documentation** URL to get documentation on the image (string, must be a URL with scheme HTTP or HTTPS)
-    * **appc.io/executor/supports-systemd-notify** (boolean, optional, defaults to "false" if unset) if set to true, the application SHOULD use the sd\_notify mechanism to signal when it is ready. Also it SHOULD be able to detect if the executor had not set up the sd\_notify mechanism and skip the notification without error ([sd_notify()](https://www.freedesktop.org/software/systemd/man/sd_notify.html) from libsystemd does that automatically).
+    * **appc.io/executor/supports-systemd-notify** (string boolean, optional, defaults to "false" if unset) if set to "true", the application SHOULD use the sd\_notify mechanism to signal when it is ready. Also it SHOULD be able to detect if the executor had not set up the sd\_notify mechanism and skip the notification without error ([sd_notify()](https://www.freedesktop.org/software/systemd/man/sd_notify.html) from libsystemd does that automatically).
 
 #### Dependency Matching
 


### PR DESCRIPTION
Noteworthy: validation check now rejects manifest with duplicate volume names.

This PR adds a validation check on the `volumes` array to ensure that it doesn't contain any duplicate-named volumes (and corresponding tests). Also, it clarifies string-typing of annotations.