### PR TITLE
ace: Fix manifest arch error

### DIFF
--- a/ace/image_manifest_main.json.in
+++ b/ace/image_manifest_main.json.in
@@ -4,8 +4,8 @@
     "name": "coreos.com/ace-validator-main",
     "labels": [
         { "name": "version", "value": "0.8.10" },
-        { "name": "os", "value": "@GOOS@" },
-        { "name": "arch", "value": "@GOARCH@" }
+        { "name": "os", "value": "@ACI_OS@" },
+        { "name": "arch", "value": "@ACI_ARCH@" }
     ],
     "app": {
         "exec": [

--- a/ace/image_manifest_sidekick.json.in
+++ b/ace/image_manifest_sidekick.json.in
@@ -4,8 +4,8 @@
     "name": "coreos.com/ace-validator-sidekick",
     "labels": [
         { "name": "version", "value": "0.8.10" },
-        { "name": "os", "value": "@GOOS@" },
-        { "name": "arch", "value": "@GOARCH@" }
+        { "name": "os", "value": "@ACI_OS@" },
+        { "name": "arch", "value": "@ACI_ARCH@" }
     ],
     "app": {
         "exec": [

--- a/scripts/build-ace-validator-acis
+++ b/scripts/build-ace-validator-acis
@@ -4,8 +4,13 @@ set -eu
 
 PREFIX="ace"
 : ${NO_SIGNATURE=}
-GOOS="$(go env GOOS)"
+
+ACI_OS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"
+case $GOARCH in
+	arm64)	ACI_ARCH="aarch64" ;;
+	*)	ACI_ARCH="$GOARCH" ;;
+esac
 
 if ! [[ $0 =~ "scripts/build-ace-validator-acis" ]]; then 
 	echo "invoke from repository root" 1>&2
@@ -20,7 +25,7 @@ for typ in main sidekick; do
 	layoutdir="bin/ace-validator-${typ}-layout"
 	mkdir -p ${layoutdir}/rootfs/opt/acvalidator
 	cp bin/ace-validator ${layoutdir}/rootfs/
-	sed -e "s/@GOOS@/$GOOS/" -e "s/@GOARCH@/$GOARCH/" < ${PREFIX}/image_manifest_${typ}.json.in > ${layoutdir}/manifest
+	sed -e "s/@ACI_OS@/$ACI_OS/" -e "s/@ACI_ARCH@/$ACI_ARCH/" < ${PREFIX}/image_manifest_${typ}.json.in > ${layoutdir}/manifest
 	# now build the tarball, and sign it
 	pushd ${layoutdir} >/dev/null
 		# Set a consistent timestamp so we get a consistent hash


### PR DESCRIPTION
The manifest contains values for the ACI arch and OS, not the go
language values.  To avoid confusion, change the symbols 'GOOS" and
'GOARCH' to 'ACI_OS' and 'ACI_ARCH', and provide conversion as
needed.

Fixes errors like these when run an ARM64 machines:

  bad arch "arm64" for linux (must be one of: [amd64 i386 aarch64 aarch64_be armv6l armv7l armv7b ppc64 ppc64le s390x])