### PR TITLE
schema/labels: consistently order LabelsFromMap

### DIFF
--- a/schema/types/labels.go
+++ b/schema/types/labels.go
@@ -28,7 +28,11 @@ var ValidOSArch = map[string][]string{
 
 type Labels []Label
 
-type labels Labels
+type labelsSlice Labels
+
+func (l labelsSlice) Len() int           { return len(l) }
+func (l labelsSlice) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l labelsSlice) Less(i, j int) bool { return l[i].Name < l[j].Name }
 
 type Label struct {
 	Name  ACIdentifier `json:"name"`
@@ -97,11 +101,11 @@ func (l Labels) MarshalJSON() ([]byte, error) {
 	if err := l.assertValid(); err != nil {
 		return nil, err
 	}
-	return json.Marshal(labels(l))
+	return json.Marshal(labelsSlice(l))
 }
 
 func (l *Labels) UnmarshalJSON(data []byte) error {
-	var jl labels
+	var jl labelsSlice
 	if err := json.Unmarshal(data, &jl); err != nil {
 		return err
 	}
@@ -141,6 +145,7 @@ func LabelsFromMap(labelsMap map[ACIdentifier]string) (Labels, error) {
 	if err := labels.assertValid(); err != nil {
 		return nil, err
 	}
+	sort.Sort(labelsSlice(labels))
 	return labels, nil
 }
 


### PR DESCRIPTION
Prior to this change, the slice of labels produced by LabelsFromMap
could have any arbitrary ordering.

See https://github.com/appc/docker2aci/issues/245 for one of the issues
this causes in practice.

I also renamed the type 'labels' to 'labelsSlice' since, as it was, it
was being constantly shadowed.

This is not accompanied with any spec change since labels in the appc
spec are already a slice, and thus already have a consistent ordering.
It's unfortunate that a round trip of ToMap/FromMap won't be consistent,
but I don't think any callers actually do that currently.