### PR TITLE
spec: add os/linux/apparmor-profile isolator

### DIFF
--- a/schema/types/isolator_linux_specific_test.go
+++ b/schema/types/isolator_linux_specific_test.go
@@ -127,6 +127,39 @@ func TestNewLinuxSELinuxContext(t *testing.T) {
 
 }
 
+func TestNewLinuxAppArmorContext(t *testing.T) {
+	tests := []struct {
+		inProfile string
+
+		wprofile LinuxAppArmorProfileProfile
+		werr     bool
+	}{
+		{
+			"rkt-default",
+			LinuxAppArmorProfileProfile("rkt-default"),
+			false,
+		},
+		{
+			"",
+			LinuxAppArmorProfileProfile(""),
+			true,
+		},
+	}
+	for i, tt := range tests {
+		c, err := NewLinuxAppArmorProfile(tt.inProfile)
+		if tt.werr {
+			if err == nil {
+				t.Errorf("#%d: did not get expected error", i)
+			}
+			continue
+		}
+		if gprofile := c.Profile(); !reflect.DeepEqual(gprofile, tt.wprofile) {
+			t.Errorf("#%d: got profile %#v, want profile %#v", i, gprofile, tt.wprofile)
+		}
+	}
+
+}
+
 func TestNewLinuxCapabilitiesRevokeSet(t *testing.T) {
 	tests := []struct {
 		in []string

--- a/schema/types/isolator_test.go
+++ b/schema/types/isolator_test.go
@@ -284,6 +284,20 @@ func TestIsolatorUnmarshal(t *testing.T) {
 			}`,
 			true,
 		},
+		{
+			`{
+				"name": "os/linux/apparmor-profile",
+				"value": {"profile": "rkt-default"}
+			}`,
+			false,
+		},
+		{
+			`{
+				"name": "os/linux/apparmor-profile",
+				"value": {"profile": ""}
+			}`,
+			true,
+		},
 	}
 
 	for i, tt := range tests {

--- a/spec/ace.md
+++ b/spec/ace.md
@@ -232,6 +232,33 @@ In the example above, the process will be only allowed to invoke syscalls specif
 
 In the example above, the SELinux security context `system_u:system_r:dhcpc_t:s0` will be applied to a pod or to a single application, depending on where this isolator is specified.
 
+#### os/linux/apparmor-profile
+
+* Scope: app/pod
+
+**Parameters:**
+
+* **profile** case-sensitive string containing the name of the (already loaded) AppArmor profile to apply to the current pod or application.
+
+**Notes:**
+ 1. Only a single `os/linux/apparmor-profile` isolator can be specified per-pod.
+ 2. Only a single `os/linux/apparmor-profile` isolator can be specified per-app.
+ 3. If a AppArmor security context is specified at pod level, it applies to all processes involved in running the pod.
+ 4. If specified both at pod and app level, app values override pod ones.
+ 5. Implementations MAY ignore this isolator if the host does not support AppArmor labeling.
+ 6. However, implementations MUST refuse to run the pod or application if the provided AppArmor profile is not available on the host.
+
+**Example:**
+
+```json
+"name": "os/linux/apparmor-profile",
+"value": {
+	"profile": "rkt-default"
+}
+```
+
+In the example above, the AppArmor profile `rkt-default` will be applied to a pod or to a single application, depending on where this isolator is specified.
+
 #### os/linux/capabilities-remove-set
 
 * Scope: app


### PR DESCRIPTION
AppArmor is a very widely used isolator in the GNU/Linux community,
providing an "easier to configure" alternative to SELinux. From the
perspective of AppC this is a fairly simple addition (profile data is
not included in the spec and must already be loaded into the kernel).

This feature is required for feature parity for ACI containers with OCI
ones (as AppArmor is also supported as a first-class citizen in OCI).

/cc @flavio @vrothberg
Signed-off-by: Aleksa Sarai <asarai@suse.de>