### PR TITLE
lastditch: Add omitempty to RuntimeImage.Name

### DIFF
--- a/schema/lastditch/pod.go
+++ b/schema/lastditch/pod.go
@@ -35,7 +35,7 @@ type RuntimeApp struct {
 }
 
 type RuntimeImage struct {
-	Name   string `json:"name"`
+	Name   string `json:"name,omitempty"`
 	ID     string `json:"id"`
 	Labels Labels `json:"labels,omitempty"`
 }


### PR DESCRIPTION
The appc spec sets the `omitempty` tag to RuntimeImage.Name which was
missing from lastditch's implementation of RuntimeImage.